### PR TITLE
Fix Supabase server client key fallback for public reads

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -3,10 +3,18 @@ import { cookies } from 'next/headers';
 
 export async function createClient() {
   const cookieStore = await cookies();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Missing Supabase server client credentials');
+  }
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
+    supabaseUrl,
+    supabaseKey,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
### Motivation
- The server Supabase client was instantiating with `process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` which may be undefined in deployment, causing silent failures when reading public tables (e.g. `site_assets`); I audited the repository files (notably `src/lib/supabase/server.ts`, `app/api/site-assets/route.ts`, `supabase/schema.sql`) and could not consult the Vector Store during this run. 

### Description
- Change `src/lib/supabase/server.ts` to read `NEXT_PUBLIC_SUPABASE_URL` and use `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` with a fallback to `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and throw a clear error if credentials are missing, then pass those values to `createServerClient`.

### Testing
- No automated tests were executed for this change (no test run requested), change is small and manual verification / CI is recommended to validate runtime behavior and environment variable availability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bb08d6f883309a1a4b694d7409cf)

## Summary by Sourcery

Correções de bugs:
- Impede que o cliente Supabase do lado do servidor falhe quando a chave padrão publicável (`publishable default key`) estiver indefinida, utilizando a chave `anon` como alternativa e validando as variáveis de ambiente obrigatórias.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent server-side Supabase client from failing when the publishable default key is undefined by falling back to the anon key and validating required environment variables.

</details>