### PR TITLE
Potential fix for code scanning alert no. 1233: Incomplete string escaping or encoding

### DIFF
--- a/deploy-public/_next/static/chunks/fd70414c83f183d3.js
+++ b/deploy-public/_next/static/chunks/fd70414c83f183d3.js
@@ -149,7 +149,7 @@
         i && '#' !== i[0] && (i = '#' + i),
         c && '?' !== c[0] && (c = '?' + c),
         (o = o.replace(/[?#]/g, encodeURIComponent)),
-        (c = c.replace('#', '%23')),
+        (c = c.replace(/#/g, '%23')),
         `${n}${s}${o}${c}${i}`
       );
     }


### PR DESCRIPTION
Potential fix for [https://github.com/danilonovaisv/_danilonov_portfolio/security/code-scanning/1233](https://github.com/danilonovaisv/_danilonov_portfolio/security/code-scanning/1233)

In general, to fix this kind of problem you should avoid using `string.replace('<literal>','...')` when you intend to sanitize *all* occurrences of a character. Instead, use a regular expression with the global (`g`) flag, or a library function that performs full escaping for you.

Here, the best minimal fix without changing behavior is to change the call on line 152 from replacing only the first `#` to replacing all `#` characters in `c`. We can do this by switching from a string pattern to a global regular expression: `c.replace(/#/g, '%23')`. This is consistent with line 151, which already uses a regex with the `g` flag for the pathname. No new imports or helper functions are required; the change is a single-line modification inside `function i(e)` in file `deploy-public/_next/static/chunks/fd70414c83f183d3.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Correções de bug:
- Codificar todas as ocorrências de `'#'` no componente de query da URL, em vez de apenas a primeira ocorrência, para evitar escape incompleto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Encode all occurrences of '#' in the URL query component instead of only the first instance to prevent incomplete escaping.

</details>
- Garantir que todos os caracteres `'#'` no componente de query da URL sejam codificados em porcentagem, em vez de apenas a primeira ocorrência.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correções de bug:
- Codificar todas as ocorrências de `'#'` no componente de query da URL, em vez de apenas a primeira ocorrência, para evitar escape incompleto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Encode all occurrences of '#' in the URL query component instead of only the first instance to prevent incomplete escaping.

</details>

</details>