### PR TITLE
Fix beliefs section layering, copy, and final reveal layout

### DIFF
--- a/src/components/sobre/AboutBeliefs.tsx
+++ b/src/components/sobre/AboutBeliefs.tsx
@@ -13,6 +13,7 @@ const PHRASES = [
   'Uma\nmarca\nque se\nreconhece.',
   'Um\ndetalhe\nque\nfica.',
   'Crio\npara\ngerar\npresença.',
+  'Mesmo\nquando\nnão\nestou\nali.',
   'Mesmo\nquando\nninguém\npercebe\no esforço.',
 ];
 
@@ -22,6 +23,7 @@ const COLORS = [
   'bg-pinkDetails', // Rosa Choque
   'bg-bluePrimary', // Azul Real
   'bg-purpleDetails', // Roxo Vibrante
+  'bg-pinkDetails', // Rosa Choque
 ];
 
 const FINAL_COLOR = 'bg-bluePrimary'; // Azul Real
@@ -114,12 +116,12 @@ const BackgroundController = ({ progress, colors, finalColor }: { progress: Moti
 
   useTransform(progress, (p: number) => {
     // Simple logic to detect active section
-    // 5 sections + 1 final. Range 0 to 1.
+    // 6 sections + 1 final. Range 0 to 1.
     // Approx 0.0 - 0.16 -> Section 1
     // 0.16 - 0.32 -> Section 2
     // etc.
-    const total = colors.length; // 5
-    const step = 0.8 / total; // 0.16 per section, leaving 0.2 for final
+    const total = colors.length; // 6
+    const step = 0.8 / total; // ~0.133 per section, leaving 0.2 for final
 
     if (p >= 0.8) {
       if (currentClass !== finalColor) setCurrentClass(finalColor);
@@ -131,7 +133,9 @@ const BackgroundController = ({ progress, colors, finalColor }: { progress: Moti
   });
 
   return (
-    <div className={`fixed inset-0 z-0 w-full h-full transition-colors duration-700 ease-in-out ${currentClass}`} />
+    <div
+      className={`absolute inset-0 z-0 w-full h-full pointer-events-none transition-colors duration-700 ease-in-out ${currentClass}`}
+    />
   );
 };
 

--- a/src/components/sobre/BeliefFinalSection.tsx
+++ b/src/components/sobre/BeliefFinalSection.tsx
@@ -37,7 +37,7 @@ export const BeliefFinalSection: React.FC<BeliefFinalSectionProps> = ({
   return (
     <section
       ref={ref}
-      className={`w-full h-screen flex flex-col items-center justify-center overflow-hidden px-4 ${bgColor}`}
+      className={`w-full h-screen overflow-hidden ${bgColor}`}
     >
       <motion.div
         style={{
@@ -45,17 +45,17 @@ export const BeliefFinalSection: React.FC<BeliefFinalSectionProps> = ({
           scale,
           filter: blur,
         }}
-        className="flex flex-col items-center justify-center text-center text-white font-display leading-[0.78] w-full max-w-[98vw]"
-        // Removido initial, whileInView, viewport e transition
+        className="std-grid flex h-full w-full items-center"
       >
-        <div className="text-[16vw] md:text-[14rem] tracking-tighter uppercase font-black">
-          ISSO É
-        </div>
-        <div className="text-[30vw] md:text-[25rem] font-black tracking-tighter uppercase">
-          GHOST
-        </div>
-        <div className="text-[24vw] md:text-[19rem] tracking-tighter uppercase font-black">
-          DESIGN
+        <div className="grid w-full items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+          <div className="hidden lg:flex items-center justify-center" aria-hidden="true" />
+          <div className="flex flex-col items-center text-center text-white font-display leading-[0.9] tracking-tight uppercase font-black lg:items-start lg:text-left">
+            <span className="text-[clamp(2.5rem,5vw,4rem)]">ISSO É</span>
+            <span className="text-[clamp(3.5rem,9vw,6rem)] text-bluePrimary">
+              GHOST
+            </span>
+            <span className="text-[clamp(3rem,8vw,5.5rem)]">DESIGN.</span>
+          </div>
         </div>
       </motion.div>
     </section>

--- a/src/components/sobre/BeliefFixedHeader.tsx
+++ b/src/components/sobre/BeliefFixedHeader.tsx
@@ -32,7 +32,7 @@ export const BeliefFixedHeader: React.FC<BeliefFixedHeaderProps> = ({
   return (
     <motion.header
       style={{ opacity }}
-      className="fixed inset-0 z-100 flex items-center pointer-events-none"
+      className="sticky top-0 z-30 flex h-screen items-center pointer-events-none"
     >
       <div className="std-grid w-full flex justify-end">
         <div className="flex flex-col items-end text-right w-full max-w-[320px] md:max-w-[480px] lg:max-w-[700px]">
@@ -43,12 +43,12 @@ export const BeliefFixedHeader: React.FC<BeliefFixedHeaderProps> = ({
               </motion.span>
             </div>
             <div className="overflow-hidden">
-              <motion.span style={{ y: y2 }} className="block">
+              <motion.span style={{ y: y2 }} className="block text-bluePrimary">
                 design que
               </motion.span>
             </div>
             <div className="overflow-hidden">
-              <motion.span style={{ y: y3 }} className="block">
+              <motion.span style={{ y: y3 }} className="block text-bluePrimary">
                 muda o dia
               </motion.span>
             </div>
@@ -64,7 +64,7 @@ export const BeliefFixedHeader: React.FC<BeliefFixedHeaderProps> = ({
           >
             Não pelo choque,
             <br />
-            mas pela conexão.
+            <span className="text-bluePrimary">mas pela conexão.</span>
           </motion.h2>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Fix a configuration/UX bug in the About → Beliefs section where the background/color steps and copy sequence were out of sync with the design, causing background bleed and a missing phrase in the manifesto flow.  
- Align the final reveal composition (ghost + manifesto) with the spec: two-column reveal, responsive typographic clamps and ghost shift on final scroll.  
- Note: I attempted to consult the requested GitHub repo (`danilonovaisv/DATABASE_AGENT_NEXT`) and the vector store but the GitHub repo returned 404 and no vector-store resources were available, so changes were made by inspecting and editing the local codebase under `src/components/sobre` and related config files.

### Description
- Add the missing belief line and color step: inserted the phrase `"Mesmo\nquando\nnão\nestou\nali."` in `PHRASES` and added the corresponding color entry in `COLORS` in `src/components/sobre/AboutBeliefs.tsx`, and adjusted the background step math to match 6 items.  
- Scope and refine background handling: `BackgroundController` now scopes the color background to the section (uses an absolute inset element with transition classes) to prevent bleed into other sections (`src/components/sobre/AboutBeliefs.tsx`).  
- Sticky header + highlights: convert the fixed header to a sticky, full‑height header (`sticky top-0 z-30 h-screen`) and apply `text-bluePrimary` highlights to the emphasized headline words and the subheading phrase in `src/components/sobre/BeliefFixedHeader.tsx`.  
- Final reveal layout: reworked `BeliefFinalSection` into a responsive two-column grid, replaced oversized vw text blocks with responsive `clamp()` sizes and applied `text-bluePrimary` to the key word `GHOST` (`src/components/sobre/BeliefFinalSection.tsx`).  
- Ghost positioning/animation tweak: added a parent group ref and `basePosition` computation and lerped the ghost group position (shifts left during final reveal) to create the intended reveal composition (`src/components/sobre/GhostModel.tsx`).  
- Committed changes: updated and committed `AboutBeliefs.tsx`, `BeliefFixedHeader.tsx`, `BeliefFinalSection.tsx`, and `GhostModel.tsx` with the above adjustments.

### Testing
- Attempted to start the dev server with `pnpm dev` to validate visual behavior, but Next.js failed to load `next.config.mjs` because `NEXT_PUBLIC_SUPABASE_URL` is required by the configuration, so the dev server did not start (error from `next.config.mjs`).  
- No automated unit/e2e tests (lint/typecheck/jest/playwright) were executed as part of this PR due to the local environment requirement; run `NEXT_PUBLIC_SUPABASE_URL=<your_supabase_url> pnpm dev` to start the app and visually validate the section, or run `pnpm test` after providing the necessary env values to run lint/typecheck/jest.  
- Commit created locally and includes the described modifications (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979124f4ea08330b7b7a2fc5732ba24)

## Summary by Sourcery

Alinhar os visuais e as interações da seção About → Beliefs com o manifesto pretendido e o design final de revelação.

Novas funcionalidades:
- Adicionar uma frase de crença adicional e um passo de cor correspondente para completar a sequência do manifesto.

Correções de bugs:
- Corrigir a lógica de transição do plano de fundo das crenças para que os passos de cor permaneçam em sincronia com o texto e não invadam outras seções.

Melhorias:
- Converter o cabeçalho de crenças em um elemento sticky de altura total e destacar frases-chave usando a cor primária.
- Redesenhar a revelação final das crenças em um layout responsivo de duas colunas com tipografia limitada (clamped) e estilização enfatizada das palavras-chave.
- Ajustar o posicionamento do modelo fantasma para interpolar horizontalmente durante a revelação final, resultando em uma composição mais intencional.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the About → Beliefs section visuals and interactions with the intended manifesto and final reveal design.

New Features:
- Add an additional belief phrase and matching color step to complete the manifesto sequence.

Bug Fixes:
- Fix belief background transition logic so color steps stay in sync with the text and do not bleed into other sections.

Enhancements:
- Convert the beliefs header into a sticky, full-height element and highlight key phrases using the primary color.
- Redesign the final beliefs reveal into a responsive two-column layout with clamped typography and emphasized keyword styling.
- Adjust the ghost model positioning to interpolate horizontally during the final reveal for a more intentional composition.

</details>

Novos recursos:
- Adicionar uma frase de crença adicional e o passo de cor correspondente para completar a sequência do manifesto.

Correções de bugs:
- Corrigir a lógica e o escopo das transições de fundo das crenças para que os passos de cor permaneçam sincronizados com o texto e não se propaguem para outras seções.

Aperfeiçoamentos:
- Converter o cabeçalho de crenças em um elemento fixo (sticky), com altura total, e enfatizar frases-chave com destaques na cor primária.
- Redesenhar a revelação final das crenças em uma grade responsiva de duas colunas, com tipografia “clamped” e estilização destacada para palavras-chave.
- Ajustar o posicionamento do modelo do ghost para interpolar horizontalmente durante a revelação final no scroll, obtendo uma composição mais intencional.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Alinhar os visuais e as interações da seção About → Beliefs com o manifesto pretendido e o design final de revelação.

Novas funcionalidades:
- Adicionar uma frase de crença adicional e um passo de cor correspondente para completar a sequência do manifesto.

Correções de bugs:
- Corrigir a lógica de transição do plano de fundo das crenças para que os passos de cor permaneçam em sincronia com o texto e não invadam outras seções.

Melhorias:
- Converter o cabeçalho de crenças em um elemento sticky de altura total e destacar frases-chave usando a cor primária.
- Redesenhar a revelação final das crenças em um layout responsivo de duas colunas com tipografia limitada (clamped) e estilização enfatizada das palavras-chave.
- Ajustar o posicionamento do modelo fantasma para interpolar horizontalmente durante a revelação final, resultando em uma composição mais intencional.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the About → Beliefs section visuals and interactions with the intended manifesto and final reveal design.

New Features:
- Add an additional belief phrase and matching color step to complete the manifesto sequence.

Bug Fixes:
- Fix belief background transition logic so color steps stay in sync with the text and do not bleed into other sections.

Enhancements:
- Convert the beliefs header into a sticky, full-height element and highlight key phrases using the primary color.
- Redesign the final beliefs reveal into a responsive two-column layout with clamped typography and emphasized keyword styling.
- Adjust the ghost model positioning to interpolate horizontally during the final reveal for a more intentional composition.

</details>

</details>