### PR TITLE
Add Finch-style DOM portfolio grid and item components

### DIFF
--- a/src/components/portfolio/PortfolioGrid.module.css
+++ b/src/components/portfolio/PortfolioGrid.module.css
@@ -1,0 +1,41 @@
+/* -----------------------------------------------------------------------------
+ * PortfolioGrid.module.css
+ * CSS Grid with custom breakpoints to match Finch Portfolio 6 layout.
+ * - Mobile (<576px): 1 column
+ * - Tablet Portrait (>=576px): 2 columns, 20px gap
+ * - Tablet Landscape (>=769px): 3 columns
+ * - Desktop Standard (992px - 1199px): uses --columns-desktop (3 or 4)
+ * - Large Desktop (>=1200px): 4 columns
+ * --------------------------------------------------------------------------- */
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+@media (min-width: 576px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px;
+  }
+}
+
+@media (min-width: 769px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 24px;
+  }
+}
+
+@media (min-width: 992px) and (max-width: 1199px) {
+  .grid {
+    grid-template-columns: repeat(var(--columns-desktop, 3), minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/src/components/portfolio/PortfolioGrid.tsx
+++ b/src/components/portfolio/PortfolioGrid.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useBodyLock } from '@/hooks/useBodyLock';
+import PortfolioItem, { PortfolioGridProject } from './PortfolioItem';
+import styles from './PortfolioGrid.module.css';
+
+interface PortfolioGridProps {
+  projects: PortfolioGridProject[];
+  /**
+   * Controla a quantidade de colunas entre 992px e 1199px.
+   * Aceita 3 ou 4 para espelhar o layout da referência.
+   */
+  columnsDesktop?: 3 | 4;
+  className?: string;
+}
+
+export default function PortfolioGrid({
+  projects,
+  columnsDesktop = 3,
+  className,
+}: PortfolioGridProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [activeProject, setActiveProject] = useState<PortfolioGridProject | null>(null);
+  const normalizedColumns = columnsDesktop === 4 ? 4 : 3;
+
+  const gridStyle = useMemo(
+    () => ({
+      ['--columns-desktop' as string]: normalizedColumns,
+    }),
+    [normalizedColumns]
+  );
+
+  useBodyLock(!!activeProject);
+
+  const handleClose = useCallback(() => {
+    setActiveProject(null);
+  }, []);
+
+  useEffect(() => {
+    if (!activeProject) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [activeProject, handleClose]);
+
+  return (
+    <section className={className} aria-label="Portfolio Grid">
+      {/*
+        Breakpoints controlados via CSS module para reproduzir o layout Finch:
+        - <576px: 1 coluna
+        - 576px: 2 colunas, gap 20px
+        - 769px: 3 colunas
+        - 992px-1199px: usa columnsDesktop
+        - >=1200px: 4 colunas
+      */}
+      <div className="mx-auto w-full max-w-[1680px] px-4 sm:px-6 md:px-12 lg:px-24">
+        <div className={styles.grid} style={gridStyle}>
+          {projects.map((project) => (
+            <PortfolioItem
+              key={project.id}
+              project={project}
+              onOpenDescription={setActiveProject}
+            />
+          ))}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {activeProject && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.button
+              type="button"
+              aria-label="Fechar modal"
+              onClick={handleClose}
+              className="absolute inset-0 bg-black/70"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            />
+
+            <motion.div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="portfolio-modal-title"
+              className="relative z-10 w-full max-w-2xl rounded-3xl border border-white/10 bg-slate-950/90 p-6 text-white shadow-[0_30px_80px_rgba(0,0,0,0.4)] backdrop-blur-lg sm:p-8"
+              initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 20 }}
+              transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-white/10 text-white transition hover:bg-white/20"
+                aria-label="Fechar modal"
+              >
+                <span aria-hidden>×</span>
+              </button>
+
+              <p className="text-xs uppercase tracking-[0.3em] text-white/60">
+                {activeProject.category}
+              </p>
+              <h3 id="portfolio-modal-title" className="mt-3 text-2xl font-semibold">
+                {activeProject.title}
+              </h3>
+              <p className="mt-4 text-base leading-relaxed text-white/80">
+                {activeProject.description ?? 'Descrição detalhada em breve.'}
+              </p>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/src/components/portfolio/PortfolioItem.tsx
+++ b/src/components/portfolio/PortfolioItem.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { motion, useReducedMotion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+export interface PortfolioGridProject {
+  id: string;
+  title: string;
+  category: string;
+  landingPageUrl?: string | null;
+  description?: string;
+  image?: string;
+}
+
+interface PortfolioItemProps {
+  project: PortfolioGridProject;
+  onOpenDescription: (_project: PortfolioGridProject) => void;
+  className?: string;
+}
+
+const hoverEase: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+export default function PortfolioItem({
+  project,
+  onOpenDescription,
+  className,
+}: PortfolioItemProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const hoverScale = prefersReducedMotion ? 1 : 1.05;
+
+  const cardContent = (
+    <motion.div
+      className={cn(
+        'group relative isolate overflow-hidden rounded-2xl border border-white/10 bg-white/5 text-left shadow-[0_20px_60px_rgba(0,0,0,0.25)]',
+        className
+      )}
+      initial="rest"
+      animate="rest"
+      whileHover="hover"
+    >
+      <div className="relative aspect-[4/3] w-full">
+        {project.image ? (
+          <motion.div
+            className="absolute inset-0"
+            variants={{
+              rest: { scale: 1 },
+              hover: { scale: hoverScale, transition: { duration: 0.4, ease: hoverEase } },
+            }}
+          >
+            <Image
+              src={project.image}
+              alt={project.title}
+              fill
+              sizes="(min-width: 1200px) 25vw, (min-width: 992px) 33vw, (min-width: 769px) 33vw, (min-width: 576px) 50vw, 100vw"
+              className="object-cover"
+            />
+          </motion.div>
+        ) : (
+          <motion.div
+            className="absolute inset-0 bg-linear-to-br from-slate-800 via-slate-900 to-slate-950"
+            variants={{
+              rest: { scale: 1 },
+              hover: { scale: hoverScale, transition: { duration: 0.4, ease: hoverEase } },
+            }}
+          />
+        )}
+        <motion.div
+          className="absolute inset-0 bg-black/60"
+          variants={{
+            rest: { opacity: 0 },
+            hover: { opacity: 1, transition: { duration: 0.4, ease: hoverEase } },
+          }}
+        />
+
+        <motion.div
+          className="absolute inset-x-0 bottom-0 p-4 sm:p-5"
+          variants={{
+            rest: { opacity: 0, y: 20 },
+            hover: { opacity: 1, y: 0, transition: { duration: 0.4, ease: hoverEase } },
+          }}
+        >
+          <p className="text-xs uppercase tracking-[0.25em] text-white/70">
+            {project.category}
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-white sm:text-xl">
+            {project.title}
+          </h3>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+
+  if (project.landingPageUrl) {
+    const isExternal = project.landingPageUrl.startsWith('http');
+
+    if (isExternal) {
+      return (
+        <a
+          href={project.landingPageUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          aria-label={`Abrir ${project.title} em nova aba`}
+        >
+          {cardContent}
+        </a>
+      );
+    }
+
+    return (
+      <Link
+        href={project.landingPageUrl}
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+        aria-label={`Visitar ${project.title}`}
+      >
+        {cardContent}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenDescription(project)}
+      className="block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      aria-label={`Abrir detalhes de ${project.title}`}
+    >
+      {cardContent}
+    </button>
+  );
+}

--- a/src/components/portfolio/index.ts
+++ b/src/components/portfolio/index.ts
@@ -10,6 +10,8 @@ export { default as PortfolioCard } from './PortfolioCard';
 export { PortfolioCardParallax } from './PortfolioCardParallax';
 export { default as CategoryFilter } from './CategoryFilter';
 export { default as PortfolioModalNew } from './PortfolioModalNew';
+export { default as PortfolioGrid } from './PortfolioGrid';
+export { default as PortfolioItem } from './PortfolioItem';
 
 // Content layouts
 export { default as TypeAContent } from './content/TypeAContent';


### PR DESCRIPTION
### Motivation
- Recreate the "Finch Portfolio 6" grid as a modern, DOM-based component set (remove any 3D / R3F dependencies) while preserving the visual distribution and interaction style from the reference.
- Provide a semantic, CSS Grid implementation with explicit responsive breakpoints to match the requested layout behavior (mobile → large desktop) and consistent image aspect-ratios.
- I inspected the local repository for existing portfolio components (`src/components/portfolio/*`) to reuse conventions and found existing modal and card patterns; the remote GitHub URL returned a page-not-found response and the vector store was not available during this run, so changes were made against the local codebase only.

### Description
- Added `src/components/portfolio/PortfolioGrid.tsx` (React + TypeScript, App Router / client component) which renders a CSS Grid controlled by a `columnsDesktop` prop and opens a modal/lightbox when a project has no `landingPageUrl`.
- Added `src/components/portfolio/PortfolioItem.tsx` (React + TypeScript) which implements the card UI: responsive `aspect-[4/3]` image via `next/image`, 2D hover interactions with `framer-motion` (scale 1 → 1.05, overlay fade in, title/category translateY + opacity), and intelligent click handling for external/internal links vs modal fallback.
- Added `src/components/portfolio/PortfolioGrid.module.css` implementing the required breakpoints: Mobile (<576px) 1 column, 576–768px 2 columns with 20px gap, 769–991px 3 columns, 992–1199px configurable via `--columns-desktop` (prop `columnsDesktop`), and >=1200px 4 columns; images use `object-cover` via `next/image` for consistent aspect-ratio handling.
- Exported the new components from the portfolio barrel file (`src/components/portfolio/index.ts`) so they can be imported alongside existing portfolio pieces.

### Testing
- No automated tests were executed as part of this change (no `pnpm`, `jest`, `tsc` or `eslint` runs were performed), so there are no test results to report.
- Recommended next steps: run `pnpm run build` or `pnpm run test:portfolio` and `pnpm run lint`/`pnpm run typecheck` locally or in CI to validate types, linting and integration with the rest of the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981731830bc8330ba8f7d636d86c94f)

## Summary by Sourcery

Introduz um layout de grid de portfólio baseado em DOM com breakpoints responsivos e suporte a modal, juntamente com itens de cartão de portfólio reutilizáveis, e os expõe por meio do arquivo barrel de componentes de portfólio.

Novos recursos:
- Adiciona um componente React `PortfolioGrid` que renderiza um layout de portfólio em CSS Grid responsivo, com contagens configuráveis de colunas em desktop e um fallback em modal para descrições de projetos.
- Adiciona um componente React `PortfolioItem` que representa um cartão de portfólio individual com imagem, interações de hover e comportamento flexível de link ou modal.

Melhorias:
- Define um módulo CSS dedicado para `PortfolioGrid` que codifica o comportamento necessário de colunas e espaçamento (gap) orientado por breakpoints para diferentes tamanhos de viewport.
- Exporta os novos componentes `PortfolioGrid` e `PortfolioItem` do barrel `index` de portfólio para integrá-los ao conjunto existente de componentes de portfólio.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a DOM-based portfolio grid layout with responsive breakpoints and modal support, along with reusable portfolio card items, and expose them via the portfolio components barrel file.

New Features:
- Add a PortfolioGrid React component that renders a responsive CSS Grid portfolio layout with configurable desktop column counts and a modal fallback for project descriptions.
- Add a PortfolioItem React component representing an individual portfolio card with image, hover interactions, and flexible link or modal behavior.

Enhancements:
- Define a dedicated CSS module for PortfolioGrid that encodes the required breakpoint-driven column and gap behavior for different viewport sizes.
- Export the new PortfolioGrid and PortfolioItem components from the portfolio index barrel to integrate them with the existing portfolio component set.

</details>