### PR TITLE
Refactor ClientLayout to remove redundant SmoothScroll provider

### DIFF
--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import SmoothScroll from '@/components/layout/SmoothScroll';
 import Header from '@/components/layout/Header';
 
 import { useExperience } from '@/hooks/useExperience';
-import { useEffect } from 'react';
 
 import { AntigravityDebugger } from '@/components/debug/AntigravityDebugger';
 
 /**
  * Client-side layout wrapper that handles:
- * - Smooth scrolling (Lenis)
  * - Experience orchestration (device detection, WebGL flags)
  * - Header/Footer rendering
  * - Debug overlay
@@ -50,12 +47,12 @@ export default function ClientLayout({
   }
 
   return (
-    <SmoothScroll>
+    <>
       <Header />
       <main id="main-content" className="relative grow">
         {children}
       </main>
       {process.env.NODE_ENV === 'development' && <AntigravityDebugger />}
-    </SmoothScroll>
+    </>
   );
 }


### PR DESCRIPTION
**What:**
Removed the nested `SmoothScroll` provider from `src/components/layout/ClientLayout.tsx`.

**Why:**
`RootLayout` already wraps the application in `SmoothScroll`. Having a second `SmoothScroll` provider inside `ClientLayout` creates duplicate Lenis instances attached to the window, which is incorrect and can cause scrolling issues.

**Verification:**
- Verified via code inspection that `RootLayout` wraps `ClientLayout` (via `AssetLoaderWrapper`) in `SmoothScroll`.
- Confirmed that `SmoothScroll` component provides `ScrollContext` and handles Lenis instantiation.
- Verified that `ClientLayout`'s children (`Header`, `main`, `AntigravityDebugger`) do not explicitly depend on the *inner* `SmoothScroll` instance specifically (they consume the context provided by the nearest provider, which is now the one from `RootLayout`).
- Restored `useEffect` logic for `admin-page` class to prevent regression as requested in code review.
- Cleaned up unrelated file changes (`package-lock.json`, etc.).

**Result:**
Cleaner component hierarchy and correct single-instance usage of Lenis for smooth scrolling.

---
*PR created automatically by Jules for task [8856352451497667727](https://jules.google.com/task/8856352451497667727) started by @danilonovaisv*

## Summary by Sourcery

Melhorias:
- Simplificar `ClientLayout` removendo um provedor `SmoothScroll` interno e renderizando seus filhos diretamente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify ClientLayout by removing an inner SmoothScroll provider and rendering its children directly.

</details>