### PR TITLE
test: add edge cases for normalizeStoragePath

### DIFF
--- a/test/unit/supabase-urls.test.ts
+++ b/test/unit/supabase-urls.test.ts
@@ -105,6 +105,79 @@ describe('Supabase URL Utilities', () => {
         'intro.mp4'
       );
     });
+
+    describe('edge cases', () => {
+      it('handles duplicate slashes', () => {
+        expect(normalizeStoragePath('//folder//file.png')).toBe(
+          'folder//file.png'
+        );
+        expect(normalizeStoragePath('folder///file.png')).toBe(
+          'folder///file.png'
+        );
+      });
+
+      it('preserves dot segments', () => {
+        expect(normalizeStoragePath('folder/./file.png')).toBe(
+          'folder/./file.png'
+        );
+        expect(normalizeStoragePath('folder/../file.png')).toBe(
+          'folder/../file.png'
+        );
+      });
+
+      it('handles special characters and unicode', () => {
+        expect(normalizeStoragePath('folder/my file.png')).toBe(
+          'folder/my file.png'
+        );
+        expect(normalizeStoragePath('folder/fílè.png')).toBe('folder/fílè.png');
+        expect(normalizeStoragePath('folder/🚀.png')).toBe('folder/🚀.png');
+      });
+
+      it('handles mixed malformed inputs', () => {
+        expect(normalizeStoragePath('file_path: key: "folder/file.png"')).toBe(
+          'folder/file.png'
+        );
+        expect(normalizeStoragePath('"\'folder/file.png\'"')).toBe(
+          'folder/file.png'
+        );
+      });
+
+      it('handles bucket prefix collisions correctly', () => {
+        // Should NOT strip if it's just a prefix match but not a folder match
+        expect(normalizeStoragePath('testing/image.png', 'test')).toBe(
+          'testing/image.png'
+        );
+        // Should strip if it matches bucket name + slash
+        expect(normalizeStoragePath('test/image.png', 'test')).toBe(
+          'image.png'
+        );
+      });
+
+      it('normalizes legacy extensions case-insensitively', () => {
+        expect(normalizeStoragePath('folder/image/JPG')).toBe(
+          'folder/image.JPG'
+        );
+        expect(normalizeStoragePath('folder/video/MP4')).toBe(
+          'folder/video.MP4'
+        );
+      });
+
+      it('does not normalize extensions not in the list', () => {
+        expect(normalizeStoragePath('folder/data/txt')).toBe('folder/data/txt');
+      });
+
+      it('removes render/image prefix', () => {
+        const url =
+          'https://project.supabase.co/storage/v1/render/image/public/bucket/file.png';
+        expect(normalizeStoragePath(url, 'bucket')).toBe('file.png');
+      });
+
+      it('handles urls with query parameters', () => {
+        const url =
+          'https://project.supabase.co/storage/v1/object/public/bucket/file.png?width=100';
+        expect(normalizeStoragePath(url, 'bucket')).toBe('file.png?width=100');
+      });
+    });
   });
 
   describe('buildSupabaseStorageUrl', () => {


### PR DESCRIPTION
🎯 **What:**
Improved test coverage for `normalizeStoragePath` in `src/lib/supabase/urls.ts` by adding comprehensive edge case scenarios.

📊 **Coverage:**
New test cases cover:
- Duplicate and mixed slashes
- Path traversal segments (`.` and `..`)
- Special characters, unicode, and emojis
- Complex malformed inputs (mixed quotes, multiple prefixes)
- Bucket prefix collisions
- Legacy extension normalization (case insensitivity)
- Supabase URL variations (render/image vs object)
- Query parameters handling

✨ **Result:**
Significant increase in confidence for `normalizeStoragePath` stability against varied and malformed inputs. verified that current implementation handles these cases correctly or as expected.

---
*PR created automatically by Jules for task [644701609216769222](https://jules.google.com/task/644701609216769222) started by @danilonovaisv*

## Summary by Sourcery

Expandir a cobertura de testes para `normalizeStoragePath` para abranger uma ampla variedade de entradas de casos extremos e variantes de URL.

Tests:
- Adicionar testes de casos extremos para barras duplicadas e mistas em caminhos de armazenamento.
- Adicionar testes para caminhos com segmentos de ponto, caracteres especiais, unicode e emojis em caminhos de armazenamento.
- Adicionar testes para entradas malformadas, comportamento de colisão de prefixo de bucket e normalização de extensões legadas.
- Adicionar testes cobrindo formatos de URL de renderização/imagem e objeto do Supabase, incluindo o tratamento de parâmetros de query.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand test coverage for normalizeStoragePath to cover a wide range of edge-case inputs and URL variants.

Tests:
- Add edge-case tests for duplicate and mixed slashes in storage paths.
- Add tests for dot-segment paths, special characters, unicode, and emojis in storage paths.
- Add tests for malformed inputs, bucket prefix collision behavior, and legacy extension normalization.
- Add tests covering Supabase render/image and object URL formats, including handling of query parameters.

</details>