### PR TITLE
Potential fix for code scanning alert no. 37372: Incomplete string escaping or encoding

### DIFF
--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -561,6 +561,11 @@ function truncate(value, limit) {
   return `${value.slice(0, limit - 3)}...`;
 }
 
+function escapeMarkdownTableCell(text) {
+  // First escape backslashes, then pipe characters used as table separators.
+  return text.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+}
+
 function renderCatalogMarkdown(catalog) {
   const lines = [];
   lines.push('# Skill Catalog');
@@ -583,9 +588,8 @@ function renderCatalogMarkdown(catalog) {
     lines.push('| --- | --- | --- | --- |');
 
     for (const skill of grouped) {
-      const description = truncate(skill.description, 160).replace(
-        /\|/g,
-        '\\|'
+      const description = escapeMarkdownTableCell(
+        truncate(skill.description, 160)
       );
       const tags = skill.tags.join(', ');
       const triggers = skill.triggers.join(', ');


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37372](https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37372)

In general: when escaping characters for a specific format (here, Markdown tables), escape *all* relevant meta-characters, including the escape character itself (backslash), and use global regex replacements rather than single `String.replace` with a plain string. For this specific case, ensure that backslashes are escaped before escaping `|`, so that you don’t create sequences where the backslash is interpreted as escaping the newly added escape sequence.

Best single fix with minimal behavior change:

- Introduce a small helper function, e.g. `escapeMarkdownTableCell(text)`, near `renderCatalogMarkdown`.
- In that helper, first escape backslashes globally (`/\\/g` → `'\\\\'`), then escape pipe characters globally (`/\|/g` → `'\\|'`).
- Replace the inline `.replace(/\|/g, '\\|')` call with a call to the helper.

This keeps existing functionality (escaping `|`) and extends it to escape backslashes as CodeQL recommends, confined to table cell content used in `renderCatalogMarkdown`. No new imports are required; standard JavaScript `replace` with regex is sufficient.

Concretely in `scripts/build-catalog.js`:

- Just above `function renderCatalogMarkdown(catalog) { ... }`, add the `escapeMarkdownTableCell` function.
- Inside `renderCatalogMarkdown`, replace:

```js
const description = truncate(skill.description, 160).replace(
  /\|/g,
  '\\|'
);
```

with:

```js
const description = escapeMarkdownTableCell(
  truncate(skill.description, 160)
);
```

This directly addresses the incomplete escaping without altering surrounding logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Melhora o escape de células de tabela Markdown no script de build do catálogo para corrigir um alerta de varredura de código sobre codificação de string incompleta.

Correções de bug:
- Corrige o escape de células de tabela Markdown para descrições de habilidades, tratando tanto barras invertidas quanto caracteres de pipe no catálogo gerado.

Melhorias:
- Introduz um helper reutilizável `escapeMarkdownTableCell` e o utiliza em `renderCatalogMarkdown` para centralizar a lógica de escape de células de tabela Markdown.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Markdown table cell escaping in the catalog build script to address a code scanning alert about incomplete string encoding.

Bug Fixes:
- Correct Markdown table cell escaping for skill descriptions by handling both backslashes and pipe characters in the generated catalog.

Enhancements:
- Introduce a reusable escapeMarkdownTableCell helper and use it in renderCatalogMarkdown to centralize Markdown table cell escaping logic.

</details>
- Corrige o escape incompleto do conteúdo de células de tabelas em Markdown, passando a tratar tanto barras invertidas quanto caracteres de pipe nas descrições de habilidades.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhora o escape de células de tabela Markdown no script de build do catálogo para corrigir um alerta de varredura de código sobre codificação de string incompleta.

Correções de bug:
- Corrige o escape de células de tabela Markdown para descrições de habilidades, tratando tanto barras invertidas quanto caracteres de pipe no catálogo gerado.

Melhorias:
- Introduz um helper reutilizável `escapeMarkdownTableCell` e o utiliza em `renderCatalogMarkdown` para centralizar a lógica de escape de células de tabela Markdown.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Markdown table cell escaping in the catalog build script to address a code scanning alert about incomplete string encoding.

Bug Fixes:
- Correct Markdown table cell escaping for skill descriptions by handling both backslashes and pipe characters in the generated catalog.

Enhancements:
- Introduce a reusable escapeMarkdownTableCell helper and use it in renderCatalogMarkdown to centralize Markdown table cell escaping logic.

</details>

</details>


___

### **PR Type**
Bug fix


___

### **Description**
- Adds `escapeMarkdownTableCell()` helper function for proper Markdown escaping

- Escapes backslashes before pipe characters to prevent incomplete encoding

- Replaces inline escape logic with centralized helper function call

- Fixes code scanning alert for incomplete string escaping in table cells


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incomplete escaping<br/>in renderCatalogMarkdown"] -->|Add helper function| B["escapeMarkdownTableCell()"]
  B -->|Escape backslashes first| C["Replace /\\\\/g"]
  C -->|Then escape pipes| D["Replace /\|/g"]
  D -->|Use in description| E["Secure table cell content"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-catalog.js</strong><dd><code>Add proper Markdown table cell escaping helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build-catalog.js

<ul><li>Introduces <code>escapeMarkdownTableCell()</code> helper function that escapes <br>backslashes globally before pipe characters<br> <li> Replaces inline <code>.replace(/\|/g, '\\|')</code> call with the new helper <br>function<br> <li> Ensures proper order of escaping to prevent backslash interpretation <br>issues<br> <li> Fixes code scanning alert 37372 for incomplete string escaping in <br>Markdown table cells</ul>


</details>


  </td>
  <td><a href="https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/pull/340/files#diff-b6c3f5a67cbbb1a52ec8e35579f5a86d3782ac9e3a9f54fbd3de22d5e95bd810">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

