### PR TITLE
fix(ci): stabilize Firebase project resolution in deploy workflow

### DIFF
--- a/.context/logs/2026-02-28-firebase-deploy-plan.md
+++ b/.context/logs/2026-02-28-firebase-deploy-plan.md
@@ -1,0 +1,16 @@
+# Implementation Plan — Firebase Deploy Permission Failure
+
+## Contexto
+Pipeline falhando no step de deploy com erro de acesso ao projeto Firebase.
+
+## Plano de implementação
+1. Remover acoplamento ao project id hardcoded no workflow de deploy.
+2. Resolver `project_id` dinamicamente (secret explícito -> service account autenticada -> `.firebaserc`).
+3. Adicionar validação prévia de acesso da Service Account ao projeto resolvido.
+4. Usar o mesmo project id resolvido no comando `firebase deploy` e mensagem de sucesso.
+5. Registrar achado em `AUDIT_PENTEST.md` para rastreabilidade operacional.
+
+## Critérios de validação
+- Workflow YAML válido.
+- Fluxo falha cedo com mensagem acionável quando não houver permissão.
+- Deploy usa o mesmo projeto autenticado para evitar mismatch de credenciais.

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -114,15 +114,43 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
 
+      - name: Resolve Firebase project id
+        id: firebase_project
+        run: |
+          if [ -n "${{ secrets.FIREBASE_PROJECT_ID }}" ]; then
+            PROJECT_ID="${{ secrets.FIREBASE_PROJECT_ID }}"
+            SOURCE="GitHub Secret FIREBASE_PROJECT_ID"
+          elif [ -n "${{ steps.auth.outputs.project_id }}" ]; then
+            PROJECT_ID="${{ steps.auth.outputs.project_id }}"
+            SOURCE="Service Account project_id"
+          elif [ -f .firebaserc ]; then
+            PROJECT_ID=$(node -e "const fs=require('fs');const rc=JSON.parse(fs.readFileSync('.firebaserc','utf8'));process.stdout.write(rc?.projects?.default||'')")
+            SOURCE=".firebaserc (projects.default)"
+          fi
+
+          if [ -z "$PROJECT_ID" ]; then
+            echo "❌ ERRO: Não foi possível resolver o Firebase Project ID."
+            echo "Defina FIREBASE_PROJECT_ID no GitHub Secrets ou configure .firebaserc/projects.default"
+            exit 1
+          fi
+
+          echo "project_id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
+          echo "✅ Projeto Firebase resolvido: $PROJECT_ID ($SOURCE)"
+
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
+
+      - name: Validate Firebase project access
+        run: |
+          firebase projects:list --json > firebase-projects.json
+          node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('firebase-projects.json','utf8'));const p=(data.results||[]).some((x)=>x.projectId==='${{ steps.firebase_project.outputs.project_id }}');if(!p){console.error('❌ ERRO: Service Account autenticada não possui acesso ao projeto ${{ steps.firebase_project.outputs.project_id }}.');process.exit(1)};console.log('✅ Acesso ao projeto validado para ${{ steps.firebase_project.outputs.project_id }}')"
 
       - name: Deploy to Firebase
         run: |
           firebase experiments:enable webframeworks
           # O erro 403 nas extensões ocorre se o Service Account não tiver a role 'Firebase Admin' 
           # ou se a API de extensões estiver desativada no projeto.
-          firebase deploy --only hosting,functions --project portfolio-danilo-novais --force --non-interactive
+          firebase deploy --only hosting,functions --project "${{ steps.firebase_project.outputs.project_id }}" --force --non-interactive
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
 
@@ -130,7 +158,7 @@ jobs:
         if: success()
         run: |
           echo "✅ Deploy completed successfully!"
-          echo "🌐 Site: https://portfolio-danilo-novais.web.app"
+          echo "🌐 Site: https://${{ steps.firebase_project.outputs.project_id }}.web.app"
           echo "### Deploy Finalizado com Sucesso 🚀" >> $GITHUB_STEP_SUMMARY
           echo "Ambiente buildado com sucesso injetando variáveis seguras." >> $GITHUB_STEP_SUMMARY
 

--- a/AUDIT_PENTEST.md
+++ b/AUDIT_PENTEST.md
@@ -67,3 +67,14 @@ sudo chown -R $(whoami) ~/.npm
 rm -rf node_modules .pnpm-store
 pnpm install
 ```
+
+---
+
+## Atualização de Auditoria — 2026-02-28
+
+- **ID:** CICD-002
+- **Erro detectado:** GitHub Actions falhava com `Failed to get Firebase project portfolio-danilo-novais` por possível mismatch entre projeto hardcoded e credencial autenticada.
+- **Componente afetado:** `.github/workflows/firebase-deploy.yml`
+- **Solução aplicada:** resolução dinâmica do `project_id` (secret `FIREBASE_PROJECT_ID` -> `steps.auth.outputs.project_id` -> `.firebaserc`), validação de acesso com `firebase projects:list`, e uso consistente do ID resolvido no `firebase deploy`.
+- **Severidade:** P0 — CRÍTICO (bloqueio de deploy)
+- **Status:** RESOLVIDO


### PR DESCRIPTION
### Motivation

- Fix a failing deploy step where `firebase deploy` errored with `Failed to get Firebase project portfolio-danilo-novais` caused by a hardcoded project id that could mismatch the authenticated service account or lack IAM access.

### Description

- Added a `Resolve Firebase project id` step to `.github/workflows/firebase-deploy.yml` that determines the `project_id` in this order: `FIREBASE_PROJECT_ID` GitHub secret -> `steps.auth.outputs.project_id` (service account) -> `.firebaserc` (`projects.default`).
- Added a `Validate Firebase project access` preflight step that runs `firebase projects:list --json` and fails early if the authenticated account lacks access to the resolved project id.
- Replaced the hardcoded project id in `firebase deploy` and the success message with the resolved `${{ steps.firebase_project.outputs.project_id }}` to ensure consistent target and messaging.
- Logged the implementation plan to `.context/logs/2026-02-28-firebase-deploy-plan.md` and recorded the incident/remediation in `AUDIT_PENTEST.md` as `CICD-002`.

### Testing

- Validated the modified workflow YAML syntax with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/firebase-deploy.yml')"` which returned `ok`.
- Ran `git diff --check` on changed files which reported no problems.
- Attempted a Python/YAML validation but the environment lacked `PyYAML`, so the Ruby check was used as the YAML validator instead.
- Committed changes and created the PR; no CI run included here, so deploy-time validation will confirm IAM/secret correctness in the target environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c06042988330973483ac28afb63c)

## Summary by Sourcery

Estabilizar o workflow de GitHub Actions de deploy do Firebase, resolvendo o projeto de destino de forma dinâmica e validando o acesso antes do deploy, além de registrar o incidente e a remediação para fins de auditoria.

CI:
- Adicionar uma etapa no workflow de deploy do Firebase para resolver o ID do projeto Firebase a partir de secrets, saída da service account ou `.firebaserc` e expô-lo como output.
- Introduzir uma etapa de validação pré-deploy que verifica se a service account autenticada tem acesso ao projeto Firebase resolvido antes de executar o deploy.
- Atualizar o comando de deploy e a mensagem de sucesso para usar o ID do projeto Firebase resolvido dinamicamente em vez de um valor hardcoded.

Documentação:
- Documentar o incidente de CI/CD e sua remediação em `AUDIT_PENTEST.md` com uma nova entrada CICD-002 detalhando impacto, correção e status.
- Adicionar um log interno de plano de implementação para a falha de permissão de deploy do Firebase em `.context/logs` para referência futura.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the Firebase deploy GitHub Actions workflow by resolving the target project dynamically and validating access before deployment, and record the incident and remediation for audit purposes.

CI:
- Add a step in the Firebase deploy workflow to resolve the Firebase project id from secrets, service account output, or .firebaserc and expose it as an output.
- Introduce a pre-deploy validation step that checks the authenticated service account has access to the resolved Firebase project before running the deploy.
- Update the deploy command and success message to use the dynamically resolved Firebase project id instead of a hardcoded value.

Documentation:
- Document the CI/CD incident and its remediation in AUDIT_PENTEST.md with a new CICD-002 entry detailing impact, fix, and status.
- Add an internal implementation plan log for the Firebase deploy permission failure under .context/logs for future reference.

</details>