### PR TITLE
🎨 Palette: Add character count hint to message field

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -54,13 +54,15 @@
 - **File**: `test/mcp_config.test.ts`
 - **Agent**: Antigravity
 - **Root Cause**: The test expected the command field inside the locally loaded `mcp_config.json` to be exactly `'node'` or `'npx'`. However, `mcp_config` was capturing absolute paths like `'/Users/.../.nvm/versions/node/v20.20.0/bin/npx'` locally causing a mismatch. Additionally, `jest` ran inside a nested `.claude/worktrees/` directory duplicating the test execution, and EPERM errors occurred when trying to read the config without permission.
-- **Error Message**: 
+- **Error Message**:
+
   ```
   Expected: "node"
   Received: "/Users/danilonovais/.nvm/versions/node/v20.20.0/bin/npx"
 
   EPERM: operation not permitted, open '/Users/danilonovais/.gemini/antigravity/mcp_config.json'
   ```
+
 - **Fix Applied**: Modifiquei o arquivo de teste `test/mcp_config.test.ts` para testar nomes compatíveis usando `RegExp` validando sufixos `node|npx` cobrindo absolute e relative paths. Apliquei `try/catch` para forçar o fallback test mock quando a permissão EPERM fosse bloqueada. Atualizei o `jest.config.cjs` para adicionar `'<rootDir>/.claude/'` ao `modulePathIgnorePatterns`, impedindo a duplicidade do teste.
 - **Prevention**: Use RegEx baseada no sufixo `/node|npx$/` ao invés de equalidade exata de strings para command paths que podem escalar via variáveis de ambiente. Ignore subdiretórios de infraestrutura como worktrees no runner do Jest.
 - **Status**: Fixed

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-04-04T05:25:51.466Z",
+  "buildTimeISO": "2026-04-04T21:02:36.600Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/components/home/contact/ContactForm.tsx
+++ b/src/components/home/contact/ContactForm.tsx
@@ -253,6 +253,7 @@ const ContactForm: React.FC = () => {
                 onChange={handleChange}
                 error={errors.message}
                 required
+                minLength={10}
                 rows={4}
                 placeholder="Conte-me sobre seu projeto..."
               />

--- a/src/components/home/contact/FormFields.tsx
+++ b/src/components/home/contact/FormFields.tsx
@@ -88,7 +88,9 @@ export const TextAreaField: React.FC<TextAreaFieldProps> = ({
       <textarea
         id={id}
         aria-invalid={isInvalid ? 'true' : 'false'}
-        aria-describedby={error ? `${id}-error` : undefined}
+        aria-describedby={
+          error ? `${id}-error` : props.minLength ? `${id}-hint` : undefined
+        }
         aria-required={props.required ? 'true' : 'false'}
         className={`w-full resize-none rounded-lg border border-[#111111]/20 bg-[#f8fafc] px-4 py-4 text-[#111111] placeholder:text-[#111111]/50 transition-all outline-none focus:border-bluePrimary focus:ring-2 focus:ring-bluePrimary/20 min-h-[120px] ${
           error ? 'border-red-500' : ''
@@ -102,6 +104,14 @@ export const TextAreaField: React.FC<TextAreaFieldProps> = ({
           className="mt-2 text-xs text-red-600 font-bold uppercase"
         >
           {error}
+        </p>
+      )}
+      {!error && props.minLength && (
+        <p
+          id={`${id}-hint`}
+          className="mt-2 text-xs text-[#111111]/50 text-right"
+        >
+          {String(props.value || '').length} / {props.minLength} mínimo
         </p>
       )}
     </div>

--- a/src/components/sobre/beliefs/BeliefFixedHeader.tsx
+++ b/src/components/sobre/beliefs/BeliefFixedHeader.tsx
@@ -59,54 +59,54 @@ export const BeliefFixedHeader: React.FC<BeliefFixedHeaderProps> = ({
         style={prefersReducedMotion ? undefined : { opacity }}
         className="sticky top-0 flex h-screen pointer-events-none drop-shadow-2xl"
       >
-      <div className="std-grid w-full h-full">
-        <div className="flex h-full items-start pt-[20vh] md:items-center md:pt-0 justify-end col-span-12">
-          <div className="flex flex-col items-end text-right w-full max-w-[85vw] sm:max-w-[280px] md:max-w-[500px] lg:max-w-[850px] pr-[5%] md:pr-0">
-            {/* Primeira parte: "Acredito no..." */}
-            <div className="flex flex-col items-end text-right w-full">
-              {/* 🟣 [CONFIG VISUAL]: Define a cor do título principal e o tamanho da fonte (4xl a 7xl) */}
-              <h2 className="text-white text-[clamp(1.75rem,8vw,3rem)] md:text-5xl lg:text-6xl xl:text-7xl font-display leading-[1] tracking-tighter mb-4 md:mb-12 uppercase font-black drop-shadow-lg">
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.0, 0.1]}>
-                    Acredito no
-                  </MorphText>
-                </div>
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.02, 0.12]}>
-                    design que
-                  </MorphText>
-                </div>
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.04, 0.14]}>
-                    muda o dia
-                  </MorphText>
-                </div>
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.06, 0.16]}>
-                    de alguém.
-                  </MorphText>
-                </div>
-              </h2>
+        <div className="std-grid w-full h-full">
+          <div className="flex h-full items-start pt-[20vh] md:items-center md:pt-0 justify-end col-span-12">
+            <div className="flex flex-col items-end text-right w-full max-w-[85vw] sm:max-w-[280px] md:max-w-[500px] lg:max-w-[850px] pr-[5%] md:pr-0">
+              {/* Primeira parte: "Acredito no..." */}
+              <div className="flex flex-col items-end text-right w-full">
+                {/* 🟣 [CONFIG VISUAL]: Define a cor do título principal e o tamanho da fonte (4xl a 7xl) */}
+                <h2 className="text-white text-[clamp(1.75rem,8vw,3rem)] md:text-5xl lg:text-6xl xl:text-7xl font-display leading-[1] tracking-tighter mb-4 md:mb-12 uppercase font-black drop-shadow-lg">
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.0, 0.1]}>
+                      Acredito no
+                    </MorphText>
+                  </div>
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.02, 0.12]}>
+                      design que
+                    </MorphText>
+                  </div>
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.04, 0.14]}>
+                      muda o dia
+                    </MorphText>
+                  </div>
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.06, 0.16]}>
+                      de alguém.
+                    </MorphText>
+                  </div>
+                </h2>
 
-              {/* Segunda parte: "Não pelo choque..." */}
-              {/* 🟣 [CONFIG VISUAL]: Define a cor e tamanho do subtítulo (sm a 4xl) */}
-              <div className="flex flex-col items-end gap-1 text-white text-[clamp(0.875rem,3.8vw,1.15rem)] md:text-3xl lg:text-4xl xl:text-5xl leading-[1.2] tracking-normal font-bold drop-shadow-xl">
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.08, 0.18]}>
-                    Não pelo choque,
-                  </MorphText>
-                </div>
-                <div className="overflow-visible">
-                  <MorphText progress={progress} range={[0.1, 0.2]}>
-                    mas pela conexão.
-                  </MorphText>
+                {/* Segunda parte: "Não pelo choque..." */}
+                {/* 🟣 [CONFIG VISUAL]: Define a cor e tamanho do subtítulo (sm a 4xl) */}
+                <div className="flex flex-col items-end gap-1 text-white text-[clamp(0.875rem,3.8vw,1.15rem)] md:text-3xl lg:text-4xl xl:text-5xl leading-[1.2] tracking-normal font-bold drop-shadow-xl">
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.08, 0.18]}>
+                      Não pelo choque,
+                    </MorphText>
+                  </div>
+                  <div className="overflow-visible">
+                    <MorphText progress={progress} range={[0.1, 0.2]}>
+                      mas pela conexão.
+                    </MorphText>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </Header>
+      </Header>
     </div>
   );
 };


### PR DESCRIPTION
Added a visual character count hint to the contact form message field, linked via `aria-describedby` for improved screen reader context. This gives users immediate feedback on the 10 character minimum requirement before they submit.

---
*PR created automatically by Jules for task [8850596421409021453](https://jules.google.com/task/8850596421409021453) started by @danilonovaisv*