### PR TITLE
🎨 Palette: Add keyboard focus-visible styling to navigation links

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -57,7 +57,7 @@ export default function SiteFooter() {
             <Link
               key={link.label}
               href={link.href}
-              className="group relative text-[11px] sm:text-[12px] font-bold uppercase tracking-widest hover:opacity-80 transition-opacity duration-200 py-3 lg:py-2 flex items-center shrink-0"
+              className="group relative text-[11px] sm:text-[12px] font-bold uppercase tracking-widest hover:opacity-80 transition-all duration-200 py-3 lg:py-2 flex items-center shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bluePrimary rounded-sm"
             >
               {link.label}
               {/* Hover Underline (Desktop Only) */}
@@ -77,7 +77,7 @@ export default function SiteFooter() {
               href={social.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="transition-transform duration-200 opacity-100 lg:opacity-90 lg:hover:opacity-100 p-3 lg:p-0 flex items-center justify-center min-w-[48px] min-h-[48px] lg:min-w-0 lg:min-h-0 hover:-translate-y-0.5 will-change-transform"
+              className="transition-all duration-200 opacity-100 lg:opacity-90 lg:hover:opacity-100 p-3 lg:p-0 flex items-center justify-center min-w-[48px] min-h-[48px] lg:min-w-0 lg:min-h-0 hover:-translate-y-0.5 will-change-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bluePrimary rounded-sm"
               aria-label={social.label}
             >
               {social.icon}

--- a/src/components/layout/header/mobile/MobileMenuButton.tsx
+++ b/src/components/layout/header/mobile/MobileMenuButton.tsx
@@ -24,7 +24,7 @@ const MobileMenuButton = forwardRef<HTMLButtonElement, MobileMenuButtonProps>(
         onClick={onToggle}
         aria-label={open ? 'Fechar menu' : 'Abrir menu'}
         aria-expanded={open ? 'true' : 'false'}
-        className={`relative inline-flex items-center justify-center gap-2 bg-transparent border-0 cursor-pointer font-medium leading-none overflow-visible z-110 min-h-12 min-w-12 px-3 transition-colors duration-300 ${
+        className={`relative inline-flex items-center justify-center gap-2 bg-transparent border-0 cursor-pointer font-medium leading-none overflow-visible z-110 min-h-12 min-w-12 px-3 transition-colors duration-300 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bluePrimary ${
           open ? 'text-white' : 'text-white hover:text-primary'
         }`}
       >

--- a/src/components/layout/header/mobile/MobileMenuPanel.tsx
+++ b/src/components/layout/header/mobile/MobileMenuPanel.tsx
@@ -60,7 +60,7 @@ const MobileMenuPanel = forwardRef<HTMLElement, MobileMenuPanelProps>(
               <li key={item.href} className="overflow-hidden leading-none">
                 <button
                   onClick={() => onNavigate(item.href)}
-                  className={`sm-panel-item w-full py-4 text-4xl sm:text-5xl tracking-wide transition-all text-left leading-none uppercase will-change-transform origin-bottom min-h-[56px] active:translate-x-2 active:opacity-70 ${
+                  className={`sm-panel-item w-full py-4 text-4xl sm:text-5xl tracking-wide transition-all text-left leading-none uppercase will-change-transform origin-bottom min-h-[56px] active:translate-x-2 active:opacity-70 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white rounded-md ${
                     isActive
                       ? 'text-blueAccent font-medium underline underline-offset-4'
                       : 'text-white/80 hover:text-white font-light'
@@ -109,7 +109,7 @@ const MobileMenuPanel = forwardRef<HTMLElement, MobileMenuPanelProps>(
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={s.label}
-                className="sm-social-link flex h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-white/5 text-white transition-all hover:bg-primary hover:border-primary"
+                className="sm-social-link flex h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-white/5 text-white transition-all hover:bg-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bluePrimary"
               >
                 {s.icon}
               </a>


### PR DESCRIPTION
🎨 Palette: Add keyboard focus-visible styling to navigation links

💡 **What:** Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-bluePrimary` to interactive links and buttons in the `SiteFooter`, `MobileMenuPanel`, and `MobileMenuButton`.
🎯 **Why:** To improve accessibility for keyboard-only or screen reader users. Previously, relying solely on hover effects made it difficult for keyboard users to see what element they were focusing on, especially on custom styled navigation elements. 
♿ **Accessibility:** Added clear, visible focus indicators for critical interactive navigation elements across mobile and desktop.

---
*PR created automatically by Jules for task [9987482786512869456](https://jules.google.com/task/9987482786512869456) started by @danilonovaisv*