### PR TITLE
🎨 Palette: [UX improvement] Hide mobile menu items from tab order when closed

### DIFF
--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-04-17T19:07:24.497Z",
+  "buildTimeISO": "2026-04-17T20:40:00.384Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/components/layout/header/mobile/MobileMenuPanel.tsx
+++ b/src/components/layout/header/mobile/MobileMenuPanel.tsx
@@ -60,6 +60,7 @@ const MobileMenuPanel = forwardRef<HTMLElement, MobileMenuPanelProps>(
               <li key={item.href} className="overflow-hidden leading-none">
                 <button
                   onClick={() => onNavigate(item.href)}
+                  tabIndex={open ? 0 : -1}
                   className={`sm-panel-item w-full py-4 text-4xl sm:text-5xl tracking-wide transition-all text-left leading-none uppercase will-change-transform origin-bottom min-h-[56px] active:translate-x-2 active:opacity-70 ${
                     isActive
                       ? 'text-blueAccent font-medium underline underline-offset-4'
@@ -109,6 +110,7 @@ const MobileMenuPanel = forwardRef<HTMLElement, MobileMenuPanelProps>(
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={s.label}
+                tabIndex={open ? 0 : -1}
                 className="sm-social-link flex h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-white/5 text-white transition-all hover:bg-primary hover:border-primary"
               >
                 {s.icon}


### PR DESCRIPTION
💡 What: Added conditional `tabIndex={open ? 0 : -1}` to the navigation buttons and social links in `MobileMenuPanel`.
🎯 Why: Off-canvas/collapsible mobile menus can trap keyboard focus or allow users to tab through elements they cannot see if their `tabIndex` is not managed dynamically based on their visibility.
♿ Accessibility: Ensures correct tab sequencing by excluding hidden menu items from the document's tab flow.

---
*PR created automatically by Jules for task [8604954716870918015](https://jules.google.com/task/8604954716870918015) started by @danilonovaisv*