### PR TITLE
🎨 Palette: Improve Video Mute/Unmute button UX and accessibility

### DIFF
--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-04-18T02:34:12.374Z",
+  "buildTimeISO": "2026-04-18T20:57:31.659Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/components/home/hero/VideoManifesto.tsx
+++ b/src/components/home/hero/VideoManifesto.tsx
@@ -239,6 +239,7 @@ export function VideoManifesto({
           className="toggle-sound absolute top-3 right-3 h-14 w-14 sm:h-12 sm:w-12 rounded-full bg-black/50 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/70 transition-colors focus-visible:outline-2 focus-visible:outline-[#0048ff] focus-visible:outline-offset-2"
           onClick={() => setMuted((m: boolean) => !m)}
           aria-label={muted ? 'Ativar som do vídeo' : 'Desativar som do vídeo'}
+          title={muted ? 'Ativar som' : 'Desativar som'}
         >
           {muted ? (
             <svg

--- a/src/components/ui/YouTubePlayer.tsx
+++ b/src/components/ui/YouTubePlayer.tsx
@@ -156,9 +156,10 @@ export function YouTubePlayer({
         <button
           onClick={handleUnmute}
           className="absolute bottom-6 right-6 z-10 flex items-center gap-2 px-4 py-2 bg-black/60 hover:bg-black/80 text-white rounded-full backdrop-blur-sm transition-all shadow-lg border border-white/10 cta-button"
+          aria-label="Ativar som do vídeo"
         >
           <VolumeX className="w-5 h-5" />
-          <span className="text-sm font-medium tracking-wide">Activar Som</span>
+          <span className="text-sm font-medium tracking-wide">Ativar Som</span>
         </button>
       )}
     </div>


### PR DESCRIPTION
This PR implements a micro-UX enhancement by improving the accessibility and usability of video mute/unmute buttons. 

1. It adds a dynamic `title` tooltip to the icon-only mute/unmute button in `VideoManifesto.tsx`.
2. It fixes a Portuguese typo ("Activar Som" to "Ativar Som") and adds an `aria-label` in the `YouTubePlayer.tsx` unmute button.

These changes make the interaction more intuitive for mouse users and more accessible for screen reader users.

---
*PR created automatically by Jules for task [14624524667790516618](https://jules.google.com/task/14624524667790516618) started by @danilonovaisv*