### PR TITLE
⚡ Bolt: Reduce global layout thrashing in useGhostReveal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-25 - [Scoped CSS Variables to Prevent Global Layout Thrashing]
+**Learning:** Setting CSS variables on `document.documentElement` inside a `requestAnimationFrame` loop (like for mouse/scroll tracking effects in WebGL/Framer Motion overlays) forces the browser to trigger a global "Recalculate Style" layout thrashing on every frame, which severely spikes Main Thread usage (TBT).
+**Action:** Always scope rapidly changing CSS variables to the closest relative container element by passing a `ref` down to the hook handling the loop. Fallback to `document.documentElement` safely, but default to localization.

--- a/src/components/home/hero/HeroCopy.tsx
+++ b/src/components/home/hero/HeroCopy.tsx
@@ -24,7 +24,8 @@ export default function HeroCopy({
   const [scope, animate] = useAnimate();
 
   // Sincroniza a posição do overlay 2D com o Ghost 3D
-  useGhostReveal(ghostRef, revealRef, isLoaded && !prefersReducedMotion);
+  // ⚡ BOLT OPTIMIZATION: Passing the scope ref to avoid global style recalculation per frame
+  useGhostReveal(ghostRef, revealRef, isLoaded && !prefersReducedMotion, scope as React.RefObject<HTMLDivElement>);
 
   useEffect(() => {
     if (!prefersReducedMotion && isLoaded && scope.current) {

--- a/src/hooks/useGhostReveal.ts
+++ b/src/hooks/useGhostReveal.ts
@@ -13,7 +13,8 @@ import * as THREE from 'three';
 export function useGhostReveal(
   ghostRef: React.RefObject<THREE.Group | null> | undefined,
   revealRef: React.RefObject<HTMLDivElement | null>,
-  enabled: boolean
+  enabled: boolean,
+  containerRef?: React.RefObject<HTMLElement | null>
 ) {
   useEffect(() => {
     if (!enabled || !ghostRef?.current || !revealRef.current) return;
@@ -35,9 +36,10 @@ export function useGhostReveal(
       // Atualiza a posição do overlay usando CSS transform
       overlay.style.transform = `translate(calc(${x}vw - 50%), calc(${invertedY}vh - 50%))`;
 
-      // Seta variáveis no documento/root para uso em classes CSS (ex: mask-image)
-      document.documentElement.style.setProperty('--ghost-x', `${x}vw`);
-      document.documentElement.style.setProperty('--ghost-y', `${invertedY}vh`);
+      // ⚡ BOLT OPTIMIZATION: Aplica ao container mais próximo em vez do root para evitar Recalculate Style global
+      const target = containerRef?.current || document.documentElement;
+      target.style.setProperty('--ghost-x', `${x}vw`);
+      target.style.setProperty('--ghost-y', `${invertedY}vh`);
 
       rafId = requestAnimationFrame(updateRevealPosition);
     };
@@ -48,5 +50,5 @@ export function useGhostReveal(
     return () => {
       if (rafId) cancelAnimationFrame(rafId);
     };
-  }, [ghostRef, revealRef, enabled]);
+  }, [ghostRef, revealRef, enabled, containerRef]);
 }


### PR DESCRIPTION
⚡ Bolt: Reduce global layout thrashing in useGhostReveal

💡 What: Modified `useGhostReveal.ts` to accept an optional `containerRef` and scoped the updating of `--ghost-x` and `--ghost-y` CSS variables to this specific container instead of the global `document.documentElement`. Updated `HeroCopy.tsx` to pass its `scope` ref to the hook.
🎯 Why: Modifying CSS variables on `document.documentElement` inside a `requestAnimationFrame` loop forces the browser to recalculate styles globally for the entire DOM tree on every single frame, causing significant main thread blocking and layout thrashing.
📊 Impact: Severely reduces CPU/Main thread layout calculation per frame, eliminating layout thrashing globally and resulting in a much smoother scroll and mouse interaction on the homepage hero section.
🔬 Measurement: Can be verified using Chrome DevTools Performance tab, looking at the "Recalculate Style" task duration during mouse movement over the hero section.

---
*PR created automatically by Jules for task [556474942592317769](https://jules.google.com/task/556474942592317769) started by @danilonovaisv*