### PR TITLE
docs(audit): add PREVC planning artifacts for Home/Sobre/Portfólio

### DIFF
--- a/.context/DOCS-PORTFOLIO-PAGES/implementation_plan.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/implementation_plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan — Auditoria Orquestrada (Home, Sobre, Portfólio)
+
+A task list is an artifact that the agent uses to approach complex tasks and monitor progress on various action items...
+
+## Pipeline
+1. Intake
+2. MCP Context Layer
+3. Orchestration
+4. Execution (posterior, após aprovação)
+5. Verification
+
+## Prioridades
+- P0: semântica estrutural e acessibilidade crítica (skip link/main landmark, heading base por rota, estados de erro sem violação de token de identidade).
+- P1: SEO técnico por rota (canonical/OG específicos, consistência de JSON-LD, indexabilidade controlada por query).
+- P1: performance percebida (preload estratégico, evitar preload excessivo de vídeo, proteção de render 3D em reduced motion/mobile).
+- P2: consistência UX entre breakpoints e estados empty/loading/error.
+
+## Ajustes planejados (sem implementação nesta fase)
+- Introduzir `<main id="main-content">` nas 3 rotas alvo mantendo App Router e layout atual.
+- Validar/normalizar hierarquia de headings em componentes-chave (hero, seções, galerias).
+- Revisar metadados OG/Twitter por página para evitar reutilização indevida de imagem/copy.
+- Uniformizar estados de fallback para integração Supabase (loading/empty/error) com mensagens e CTA de recuperação.
+- Garantir conformidade motion: apenas opacity/blur/translateY e respeito a prefers-reduced-motion em toda superfície crítica.
+
+## Approval Gate
+Nenhuma correção será aplicada até comando explícito: `Aprovado` ou `Proceed`.

--- a/.context/DOCS-PORTFOLIO-PAGES/risk_assessment.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/risk_assessment.md
@@ -1,0 +1,18 @@
+# Risk Assessment — Home, Sobre, Portfólio
+
+A task list is an artifact that the agent uses to approach complex tasks and monitor progress on various action items...
+
+## Riscos Técnicos
+- **R1 (P0):** ausência de landmark principal com `id="main-content"` pode quebrar skip-link e navegação assistiva.
+- **R2 (P0):** estado de erro da rota Sobre usa token `text-redAccent`, potencial conflito com regra de identidade (não usar vermelho como cor de identidade).
+- **R3 (P1):** sobrecarga de preload de vídeo/imagem pode afetar LCP/INP em dispositivos médios.
+- **R4 (P1):** inconsistências de metadata (OG/Twitter/canonical por rota e query) podem reduzir qualidade de indexação.
+- **R5 (P2):** divergência entre fallback de dados e UX final em cenários sem Supabase.
+
+## Mitigação
+- Priorizar correções de semântica e foco (R1/R2) antes de ajustes de SEO/performance.
+- Validar com Lighthouse + axe + inspeção de headings por rota.
+- Medir Web Vitals antes/depois (LCP, INP, CLS) por desktop/mobile.
+
+## Gate
+Sem execução de patch até aprovação humana explícita.

--- a/.context/DOCS-PORTFOLIO-PAGES/task.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/task.md
@@ -1,0 +1,15 @@
+# Task List — Auditoria PREVC
+
+A task list is an artifact that the agent uses to approach complex tasks and monitor progress on various action items...
+
+## Tasks
+1. Confirmar escopo e governança (AGENTS.md, docs de página, regras locais).
+2. Mapear rotas Home (`/`), Sobre (`/sobre`) e Portfólio (`/portfolio`) no App Router.
+3. Inventariar seções/componentes por rota e breakpoints.
+4. Levantar evidências de metadados/SEO técnico por rota.
+5. Levantar evidências de acessibilidade estrutural e operacional.
+6. Levantar evidências de performance (preload, dynamic import, fallback data).
+7. Levantar evidências de estados loading/empty/error.
+8. Classificar findings em P0/P1/P2 com impacto e causa provável.
+9. Consolidar fix_plan acionável sem implementar mudanças.
+10. Preparar checklist de validação e gate de aprovação humana.


### PR DESCRIPTION
### Motivation
- Add PREVC planning artifacts to orchestrate a focused audit (Home `/`, Sobre `/sobre`, Portfólio `/portfolio`) with clear priorities, risk assessment and an explicit human approval gate before any code changes.

### Description
- Added three planning documents under `.context/DOCS-PORTFOLIO-PAGES/`: `implementation_plan.md` (PREVC pipeline, priorities, approval gate), `task.md` (objective task list) and `risk_assessment.md` (risks and mitigations).
- Artifacts define P0/P1/P2 priorities, required validations (axe/Lighthouse/Web Vitals), and the rule that no fixes are applied until explicit human approval (`Aprovado` or `Proceed`).
- No runtime/source code in `src/` was modified; this is preparation-only documentation to guide the subsequent correction swarm.

### Testing
- Performed repository inspections to validate context and targets: file existence and listing of `.context/DOCS-PORTFOLIO-PAGES/` entries succeeded.
- Performed codebase pattern scans to locate metadata, motion usage and key page entrypoints (`rg` searches) and inspected `page`/`layout` files to confirm scope; these inspections completed successfully.
- Confirmed the three new planning files are present under `.context/DOCS-PORTFOLIO-PAGES/` and included in the PR payload; all verification commands returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b8f0435c8330b3f4170e787ccc53)