### PR TITLE
feat(about): synchronize beliefs scrollytelling with Motion `scroll()` and fixed narrative

### DIFF
--- a/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/06-O-QUE-ME-MOVE-AJUSTE.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/06-O-QUE-ME-MOVE-AJUSTE.md
@@ -210,3 +210,17 @@ _O design respira. O Ghost sente. A cor absorve significado._
 | Error boundary       | `src/components/sobre/3d/GhostErrorBoundary.tsx`        |
 | Bridge DOM↔R3F       | `src/store/beliefStore.ts` (ghostIntensity)             |
 | Tokens de motion     | `src/config/motion.ts` (GHOST_EASE, GHOST_EASE_AMBIENT) |
+
+
+## 2026-05-02 — Ajuste scrollytelling Motion
+
+- Scroll tracker da seção migrado para a API `scroll()` do Motion, mantendo `offset: ["start start", "end end"]` no container da seção.
+- Frases da rotação fixadas com ordem imutável de 6 itens:
+  1. Um vídeo que respira
+  2. Uma marca que se reconhece
+  3. Um detalhe que fica
+  4. Crio para gerar presença
+  5. Mesmo quando não estou ali
+  6. Mesmo quando ninguém percebe o esforço
+- Background mapeado por keyframes exatos de progresso `[0, 0.15, 0.30, 0.45, 0.60, 0.75, 0.90, 1]` com cores `#040013 → #0048ff → #8705f2 → #f501d3 → #0048ff → #8705f2 → #f501d3 → #040013`.
+- A camada de texto mantém animação restrita a `transform` e `opacity`; com `prefers-reduced-motion`, remove deslocamento e mantém apenas cross-fade.

--- a/src/components/sobre/sections/beliefs/BeliefBackground.tsx
+++ b/src/components/sobre/sections/beliefs/BeliefBackground.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { motion, useTransform, MotionValue } from 'motion/react';
-import { colorSequence, interpolateHSL } from '@/lib/colors';
 
 interface BeliefBackgroundProps {
   scrollProgress: MotionValue<number>;
@@ -12,30 +11,37 @@ export function BeliefBackground({
   scrollProgress,
   prefersReducedMotion,
 }: BeliefBackgroundProps) {
-  // Interpolação contínua entre as cores da sequência
-  const backgroundColor = useTransform(scrollProgress, (v) => {
-    if (prefersReducedMotion) return '#040013';
+  const colorStops = [0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9, 1];
+  const colorValues = [
+    '#040013',
+    '#0048ff',
+    '#8705f2',
+    '#f501d3',
+    '#0048ff',
+    '#8705f2',
+    '#f501d3',
+    '#040013',
+  ];
 
-    const segments = colorSequence.length - 1;
-    const position = v * segments;
-    const index = Math.floor(position);
-    const nextIndex = Math.min(index + 1, segments);
-    const t = position - index;
-
-    return interpolateHSL(colorSequence[index], colorSequence[nextIndex], t);
-  });
-
-  const opacity = useTransform(
+  const backgroundColor = useTransform(
     scrollProgress,
-    [0, 0.05, 0.9, 0.98],
-    [0, 1, 1, 0]
+    colorStops,
+    colorValues,
+    {
+      clamp: true,
+    }
   );
+
+  const opacity = useTransform(scrollProgress, [0, 0.03, 0.97, 1], [1, 1, 1, 1]);
 
   return (
     <motion.div
       className="absolute inset-0 z-0 pointer-events-none"
       data-testid="beliefs-background"
-      style={{ backgroundColor, opacity }}
+      style={{
+        backgroundColor,
+        opacity: prefersReducedMotion ? 0.94 : opacity,
+      }}
       aria-hidden="true"
     />
   );

--- a/src/components/sobre/sections/beliefs/BeliefsSection.tsx
+++ b/src/components/sobre/sections/beliefs/BeliefsSection.tsx
@@ -12,12 +12,14 @@ import { BeliefSection } from '@/components/sobre/sections/beliefs/BeliefSection
 import { BeliefManifesto } from '@/components/sobre/sections/beliefs/BeliefManifesto';
 import { GhostCanvasClient } from '@/components/sobre/sections/beliefs/3d/GhostCanvasClient';
 import { GhostErrorBoundary } from '@/components/sobre/sections/beliefs/3d/GhostErrorBoundary';
-import { ABOUT_CONTENT } from '@/config/content';
-
-const PHRASES = ABOUT_CONTENT.beliefs.map((belief) => ({
-  title: 'O que me move',
-  text: belief.text,
-}));
+const PHRASES = [
+  'Um vídeo que respira',
+  'Uma marca que se reconhece',
+  'Um detalhe que fica',
+  'Crio para gerar presença',
+  'Mesmo quando não estou ali',
+  'Mesmo quando ninguém percebe o esforço',
+].map((text) => ({ title: 'O que me move', text }));
 
 export function BeliefsSection() {
   const { containerRef, scrollYProgress } = useBeliefsScroll();

--- a/src/hooks/useBeliefsScroll.ts
+++ b/src/hooks/useBeliefsScroll.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useScroll } from 'motion/react';
+import { motionValue, scroll, type MotionValue } from 'motion';
 import { useEffect, useRef, type RefObject } from 'react';
 import { useBeliefStore } from '@/store/beliefStore';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -31,10 +31,24 @@ export function useBeliefsScroll(
     };
   }, [prefersReducedMotion, setMobile, setReducedMotion]);
 
-  const { scrollYProgress } = useScroll({
-    target: containerRef,
-    offset: ['start start', 'end end'],
-  });
+  const scrollYProgressRef = useRef<MotionValue<number> | null>(null);
+  if (!scrollYProgressRef.current) {
+    scrollYProgressRef.current = motionValue(0);
+  }
 
-  return { containerRef, scrollYProgress };
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const stop = scroll((progress: number) => {
+      scrollYProgressRef.current?.set(progress);
+    }, {
+      target: node,
+      offset: ['start start', 'end end'],
+    });
+
+    return () => stop();
+  }, [containerRef]);
+
+  return { containerRef, scrollYProgress: scrollYProgressRef.current };
 }


### PR DESCRIPTION
### Motivation
- Replace previous scroll tracking with a scroll-linked API that produces a stable 0→1 progress for the beliefs scrollytelling scene.  
- Guarantee the required immutable order of the six phrases for section `06-O-QUE-ME-MOVE-AJUSTE`.  
- Map the background color choreography to explicit progress keyframes to match the design spec and avoid ambiguous interpolation behavior.  
- Maintain S-Tier performance and accessibility constraints, including `prefers-reduced-motion` and GPU-friendly text transforms.

### Description
- Migrated the section tracker from `useScroll` to Motion's `scroll()` and `motionValue` in `useBeliefsScroll` so the container produces a normalized `scrollYProgress` tied to the section element.  
- Replaced dynamic content sourcing for the rotator with a locked array of six phrases in `BeliefsSection` to enforce the immutable order requested.  
- Implemented explicit color keyframes in `BeliefBackground` using progress stops `[0, 0.15, 0.30, 0.45, 0.60, 0.75, 0.90, 1]` and colors `#040013 → #0048ff → #8705f2 → #f501d3 → #0048ff → #8705f2 → #f501d3 → #040013`, exposing the value as a `backgroundColor` Motion value.  
- Preserved text animation constraints so only `transform` and `opacity` are animated in the text layer and applied `prefers-reduced-motion` fallback that removes Y-translation and keeps a cross-fade.  
- Updated the implementation note in project docs (`.context/.../06-O-QUE-ME-MOVE-AJUSTE.md`) describing the change and keyframes.

### Testing
- Ran type checking with `pnpm run typecheck`, which completed successfully (type checks passed; environment emitted a Node/pnpm engine warning unrelated to types).  
- No automated E2E or unit tests were modified or executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6553554b88330a1fe8cf88c21df81)