### PR TITLE
fix(sobre/beliefs): align O Que Me Move (V5 blueprint)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "portfolio-dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,13 @@
       "Bash(curl -s http://localhost:3000 -o /dev/null -w \"%{http_code}\")",
       "Bash(npx playwright *)",
       "Bash(pnpm playwright *)",
-      "Bash(pnpm list *)"
+      "Bash(pnpm list *)",
+      "Read(//Users/danilonovais/.claude/plugins/cache/my-plugins/**)",
+      "Read(//Users/danilonovais/.claude/plugins/**)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); [print\\(k\\) for k in d['plugins']]\")",
+      "Bash(python3 -m json.tool)",
+      "Bash(claude plugin *)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(json.dumps\\({k:v for k,v in d.items\\(\\) if k in ['env','mcpServers','permissions']}, indent=2\\)\\)\")"
     ]
   },
   "enabledPlugins": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4088,7 +4088,6 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -4097,7 +4096,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -4315,7 +4313,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4786,7 +4783,6 @@ packages:
 
   json-ptr@3.1.1:
     resolution: {integrity: sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -5391,7 +5387,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -6779,12 +6774,10 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6853,7 +6846,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}

--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-05-05T03:59:55.662Z",
+  "buildTimeISO": "2026-05-05T05:56:28.740Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/app/sobre/loading.tsx
+++ b/src/app/sobre/loading.tsx
@@ -2,9 +2,9 @@ export default function Loading() {
   return (
     <main className="min-h-dvh bg-[#040013] text-white">
       <div className="mx-auto flex min-h-dvh max-w-7xl items-center px-6">
-        <div className="space-y-4">
-          <div className="h-3 w-48 animate-pulse rounded-full bg-white/20" />
-          <div className="h-12 w-[70vw] max-w-2xl animate-pulse rounded-xl bg-white/10" />
+        <div className="space-y-4" aria-busy="true" aria-label="Carregando">
+          <div className="h-3 w-48 rounded-full bg-white/20 motion-safe:animate-pulse" />
+          <div className="h-12 w-[70vw] max-w-2xl rounded-xl bg-white/10 motion-safe:animate-pulse" />
         </div>
       </div>
     </main>

--- a/src/components/sobre/3d/GhostModel.tsx
+++ b/src/components/sobre/3d/GhostModel.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef } from 'react';
 import { Group, MathUtils } from 'three';
 import { getAssetUrl } from '@/lib/utils';
 import { useBeliefsScrollContext } from '../beliefs/BeliefsScrollContext';
-import { usePointerParallax } from '@/hooks/usePointerParallax';
 
 const MODEL_PATH = getAssetUrl('site-assets/3d/ghost-v1.glb');
 
@@ -14,19 +13,16 @@ export function GhostModel() {
   const group = useRef<Group>(null);
   const { scrollYProgress, isMobile, shouldReduceMotion } =
     useBeliefsScrollContext();
-  const { x: pointerX, y: pointerY } = usePointerParallax();
   const { invalidate } = useThree();
   const { scene } = useGLTF(MODEL_PATH);
 
-  // Trigger re-render explicitly when scroll progress updates,
-  // since Canvas uses frameloop="demand".
+  useEffect(() => {
+    invalidate();
+  }, [scene, invalidate]);
+
   useEffect(() => {
     return scrollYProgress.on('change', () => invalidate());
   }, [scrollYProgress, invalidate]);
-
-  useEffect(() => {
-    return pointerX.on('change', () => invalidate());
-  }, [pointerX, invalidate]);
 
   useFrame((state) => {
     if (!group.current) return;
@@ -34,7 +30,6 @@ export function GhostModel() {
     const t = state.clock.elapsedTime;
     const p = scrollYProgress.get();
 
-    // Hover effect
     if (!shouldReduceMotion) {
       const floatSpeed = 0.6 + p * 0.6;
       const floatAmplitude = 0.036 + p * 0.03;
@@ -51,16 +46,12 @@ export function GhostModel() {
       );
     }
 
-    // Positions logic based on viewport and scroll climax
     let targetX = 0;
     let targetY = 0;
 
     if (isMobile) {
       targetX = -1.2;
       targetY = 1.5;
-    } else {
-      targetX = shouldReduceMotion ? 0 : pointerX.get() * 0.4;
-      targetY = shouldReduceMotion ? 0 : pointerY.get() * 0.4;
     }
 
     if (p > 0.85) {
@@ -75,15 +66,6 @@ export function GhostModel() {
     );
 
     if (isMobile) {
-      group.current.position.y = MathUtils.lerp(
-        group.current.position.y,
-        targetY +
-          (shouldReduceMotion
-            ? 0
-            : Math.sin(t * (0.6 + p * 0.6)) * (0.036 + p * 0.03)),
-        0.1
-      );
-    } else {
       const hoverY = shouldReduceMotion
         ? 0
         : Math.sin(t * (0.6 + p * 0.6)) * (0.036 + p * 0.03);
@@ -93,9 +75,6 @@ export function GhostModel() {
         0.1
       );
     }
-
-    // Invalidate if things are still moving
-    invalidate();
   });
 
   return (

--- a/src/components/sobre/3d/GhostSceneFallback.tsx
+++ b/src/components/sobre/3d/GhostSceneFallback.tsx
@@ -16,14 +16,27 @@ export function GhostSceneFallback() {
   return (
     <div
       data-testid="ghost-fallback"
+      data-ghost-scene
       className="pointer-events-none fixed inset-0 flex items-center justify-center"
       style={{ zIndex: Z_INDEX.beliefs.ghost }}
     >
-      <m.div
-        aria-hidden="true"
+      <m.svg
+        role="img"
+        aria-label="Silhueta do Ghost"
+        viewBox="0 0 200 240"
+        className="h-[44vh] w-auto md:h-[58vh]"
         style={shouldReduceMotion ? { opacity: 1 } : { opacity }}
-        className="h-48 w-48 rounded-full bg-gradient-to-tr from-blue-600/30 to-purple-600/30 blur-3xl md:h-96 md:w-96"
-      />
+        fill="none"
+      >
+        <path
+          d="M100 12c-39 0-70 31-70 70v118c0 8 9 12 15 7l18-14c4-3 9-3 13 0l18 14c4 3 10 3 14 0l18-14c4-3 9-3 13 0l18 14c6 5 15 1 15-7V82c0-39-31-70-72-70Z"
+          fill="#ffffff"
+        />
+        <ellipse cx="78" cy="100" rx="9" ry="13" fill="#040013" />
+        <ellipse cx="122" cy="100" rx="9" ry="13" fill="#040013" />
+        <path d="M40 70h120l-6-22a18 18 0 0 0-17-13H63a18 18 0 0 0-17 13L40 70Z" fill="#040013" />
+        <rect x="40" y="68" width="120" height="6" fill="#e10b1a" />
+      </m.svg>
     </div>
   );
 }

--- a/src/components/sobre/beliefs/BeliefBackground.tsx
+++ b/src/components/sobre/beliefs/BeliefBackground.tsx
@@ -1,42 +1,94 @@
 'use client';
 
-import { m, useTransform } from 'framer-motion';
-import { MOTION_TOKENS } from '@/config/motion';
+import { useEffect, useRef } from 'react';
+import { animate, inView, type AnimationPlaybackControls } from 'framer-motion';
+import { useMotionValueEvent } from 'framer-motion';
+import { GHOST_EASE_AMBIENT, MOTION_TOKENS } from '@/config/motion';
 import { useBeliefsScrollContext } from './BeliefsScrollContext';
 import { Z_INDEX } from '@/config/z-indices';
+import { BELIEF_BACKGROUND_STOPS } from '@/config/beliefTokens';
+import { BELIEF_SCROLL_THRESHOLDS } from './belief.constants';
 
-// Continuous color progression keyed to scroll progress — no inView race conditions
-const COLOR_PROGRESS = [0, 0.10, 0.24, 0.38, 0.52, 0.66, 0.80, 0.82, 1.0];
-const COLOR_VALUES = [
-  '#040013', // void
-  '#0048ff', // blue
-  '#8705f2', // purple
-  '#f501d3', // pink
-  '#0048ff', // blue
-  '#8705f2', // purple
-  '#f501d3', // pink
-  '#0048ff', // blue climax
-  '#0048ff', // locked blue
-];
+const CLIMAX_BLUE = BELIEF_BACKGROUND_STOPS[BELIEF_BACKGROUND_STOPS.length - 1];
 
 export function BeliefBackground() {
+  const bgRef = useRef<HTMLDivElement | null>(null);
+  const activeAnimRef = useRef<AnimationPlaybackControls | null>(null);
+  const climaxLockedRef = useRef(false);
   const { scrollYProgress, shouldReduceMotion } = useBeliefsScrollContext();
 
-  const backgroundColor = useTransform(
-    scrollYProgress,
-    COLOR_PROGRESS,
-    COLOR_VALUES
-  );
+  useMotionValueEvent(scrollYProgress, 'change', (progress) => {
+    const el = bgRef.current;
+    if (!el) return;
+
+    if (progress >= BELIEF_SCROLL_THRESHOLDS.finalLock) {
+      if (climaxLockedRef.current) return;
+      climaxLockedRef.current = true;
+      activeAnimRef.current?.stop();
+      activeAnimRef.current = animate(
+        el,
+        { backgroundColor: CLIMAX_BLUE } as Parameters<typeof animate>[1],
+        { duration: shouldReduceMotion ? 0 : 0.45, ease: GHOST_EASE_AMBIENT }
+      );
+      return;
+    }
+
+    if (climaxLockedRef.current && progress < BELIEF_SCROLL_THRESHOLDS.finalLock - 0.04) {
+      climaxLockedRef.current = false;
+    }
+  });
+
+  useEffect(() => {
+    const el = bgRef.current;
+    if (!el) return;
+
+    el.style.backgroundColor = BELIEF_BACKGROUND_STOPS[0];
+
+    const animateBg = (color: string, duration: number) => {
+      activeAnimRef.current?.stop();
+      activeAnimRef.current = animate(
+        el,
+        { backgroundColor: color } as Parameters<typeof animate>[1],
+        { duration, ease: GHOST_EASE_AMBIENT }
+      );
+    };
+
+    const stopInView = inView('.belief-scroll-section', (entry) => {
+      const node =
+        (entry as unknown as { target?: Element }).target ??
+        (entry as unknown as Element);
+      const idx = Number((node as HTMLElement).dataset?.index ?? 0);
+      const nextColor =
+        BELIEF_BACKGROUND_STOPS[Math.min(idx + 1, BELIEF_BACKGROUND_STOPS.length - 1)] ??
+        BELIEF_BACKGROUND_STOPS[0];
+
+      if (!climaxLockedRef.current) {
+        animateBg(nextColor, shouldReduceMotion ? 0 : 0.9);
+      }
+
+      return () => {
+        if (climaxLockedRef.current) return;
+        const prev =
+          BELIEF_BACKGROUND_STOPS[Math.max(idx, 0)] ?? BELIEF_BACKGROUND_STOPS[0];
+        animateBg(prev, shouldReduceMotion ? 0 : 0.6);
+      };
+    });
+
+    return () => {
+      activeAnimRef.current?.stop();
+      stopInView();
+    };
+  }, [shouldReduceMotion]);
 
   return (
-    <m.div
+    <div
+      ref={bgRef}
       data-testid="beliefs-background"
       data-belief-background
       aria-hidden="true"
       style={{
-        backgroundColor: shouldReduceMotion ? MOTION_TOKENS.colors.deepVoid : backgroundColor,
         zIndex: Z_INDEX.beliefs.background,
-        willChange: 'background-color',
+        backgroundColor: MOTION_TOKENS.colors.deepVoid,
       }}
       className="absolute inset-0"
     />

--- a/src/components/sobre/beliefs/BeliefFixedHeader.tsx
+++ b/src/components/sobre/beliefs/BeliefFixedHeader.tsx
@@ -14,7 +14,8 @@ export function BeliefFixedHeader() {
 
   return (
     <m.header
-      aria-hidden="true"
+      role="doc-subtitle"
+      aria-label={`${BELIEF_HEADER_LINES[0]} ${BELIEF_HEADER_LINES[1]}`}
       className="pointer-events-none fixed inset-x-0 top-[14vh] w-full py-8 md:top-0"
       style={{
         opacity,
@@ -23,7 +24,7 @@ export function BeliefFixedHeader() {
       }}
     >
       <div className="mx-auto flex max-w-[1680px] items-center justify-center px-6 md:justify-end md:px-12 lg:px-16">
-        <div className="max-w-sm text-center text-white/70 md:text-right">
+        <div aria-hidden="true" className="max-w-sm text-center text-white/70 md:text-right">
           <SplitGhostText
             as="p"
             text={BELIEF_HEADER_LINES[0]}

--- a/src/components/sobre/beliefs/BeliefManifesto.tsx
+++ b/src/components/sobre/beliefs/BeliefManifesto.tsx
@@ -5,9 +5,10 @@ import { useBeliefsScrollContext } from './BeliefsScrollContext';
 import { Z_INDEX } from '@/config/z-indices';
 import { BELIEF_MANIFESTO_LINES } from '@/config/beliefTokens';
 import { BELIEF_SCROLL_THRESHOLDS } from './belief.constants';
+import { SplitGhostText } from './SplitGhostText';
 
 export function BeliefManifesto() {
-  const { scrollYProgress, shouldReduceMotion } = useBeliefsScrollContext();
+  const { scrollYProgress, shouldReduceMotion, isClimax } = useBeliefsScrollContext();
 
   const opacity = useTransform(
     scrollYProgress,
@@ -19,6 +20,8 @@ export function BeliefManifesto() {
     [BELIEF_SCROLL_THRESHOLDS.climaxStart, BELIEF_SCROLL_THRESHOLDS.climaxEnd],
     [18, 0]
   );
+
+  const animateReveal = shouldReduceMotion ? true : isClimax;
 
   return (
     <m.div
@@ -33,25 +36,18 @@ export function BeliefManifesto() {
       }}
     >
       <div className="mx-auto w-full max-w-[1680px]">
-        {BELIEF_MANIFESTO_LINES.map((line, i) => (
-          <m.div
+        {BELIEF_MANIFESTO_LINES.map((line) => (
+          <SplitGhostText
             key={line}
-            className="block overflow-hidden"
-            initial={{ opacity: 0, y: 18 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              duration: 0.8,
-              delay: i * 0.12,
-              ease: [0.22, 1, 0.36, 1],
-            }}
-          >
-            <span
-              className="block font-extrabold uppercase text-white leading-[0.88] tracking-[0.03em]"
-              style={{ fontSize: 'clamp(4rem, 17vw, 13rem)' }}
-            >
-              {line}
-            </span>
-          </m.div>
+            as="div"
+            text={line}
+            splitType="words"
+            textAlign="center"
+            stagger={0.08}
+            duration={0.8}
+            animate={animateReveal}
+            className="block font-extrabold uppercase text-white leading-[0.88] tracking-[0.03em] text-[clamp(4rem,17vw,13rem)]"
+          />
         ))}
       </div>
     </m.div>

--- a/src/components/sobre/beliefs/BeliefScrollText.tsx
+++ b/src/components/sobre/beliefs/BeliefScrollText.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Container } from '@/components/layout/Container';
-import { m, useInView, useMotionValueEvent, useTransform } from 'framer-motion';
-import { useRef, useState } from 'react';
+import { m, useTransform } from 'framer-motion';
 import { useBeliefsScrollContext } from './BeliefsScrollContext';
 import { MOTION_TOKENS } from '@/config/motion';
 import { Z_INDEX } from '@/config/z-indices';
@@ -11,25 +10,13 @@ import { BELIEF_LAYOUT, BELIEF_PHRASE_ITEMS, BELIEF_PHRASES } from '@/config/bel
 function BeliefScrollTextItem({
   phrase,
   index,
+  isActive,
 }: {
   phrase: string;
   index: number;
+  isActive: boolean;
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const isInView = useInView(ref, {
-    margin: MOTION_TOKENS.reveal.beliefsMargin,
-    amount: 0.1,
-  });
-  const { scrollYProgress, shouldReduceMotion } = useBeliefsScrollContext();
-  const [isActiveByProgress, setIsActiveByProgress] = useState(false);
-
-  const isActive = isInView || isActiveByProgress;
-
-  useMotionValueEvent(scrollYProgress, 'change', (latest) => {
-    const start = 0.06 + index * 0.075;
-    const end = start + 0.28;
-    setIsActiveByProgress(latest >= start && latest <= end);
-  });
+  const { shouldReduceMotion } = useBeliefsScrollContext();
 
   const variants = {
     hidden: {
@@ -56,7 +43,6 @@ function BeliefScrollTextItem({
 
   return (
     <section
-      ref={ref}
       data-index={index}
       className="belief-scroll-section relative flex w-full snap-center items-end justify-center pb-[20vh] md:items-center md:justify-start md:pb-0"
       style={{ height: BELIEF_LAYOUT.phraseSectionHeight }}
@@ -64,6 +50,7 @@ function BeliefScrollTextItem({
       <Container style={{ zIndex: Z_INDEX.beliefs.scrollText }}>
         <m.div
           data-testid="belief-phrase"
+          data-active={isActive}
           data-animation-contract="viewport-y-opacity"
           initial="hidden"
           animate={isActive ? 'visible' : 'exit'}
@@ -113,6 +100,7 @@ export function BeliefScrollText() {
           key={phrase.id}
           index={index}
           phrase={phrase.text}
+          isActive={index === activePhraseIndex}
         />
       ))}
 

--- a/src/components/sobre/beliefs/BeliefScrollText.tsx
+++ b/src/components/sobre/beliefs/BeliefScrollText.tsx
@@ -1,66 +1,84 @@
 'use client';
 
 import { Container } from '@/components/layout/Container';
-import { m, useTransform } from 'framer-motion';
+import { m, useTransform, animate, inView } from 'framer-motion';
+import { useEffect, useRef } from 'react';
 import { useBeliefsScrollContext } from './BeliefsScrollContext';
-import { MOTION_TOKENS } from '@/config/motion';
+import { GHOST_EASE_AMBIENT } from '@/config/motion';
 import { Z_INDEX } from '@/config/z-indices';
 import { BELIEF_LAYOUT, BELIEF_PHRASE_ITEMS, BELIEF_PHRASES } from '@/config/beliefTokens';
+
+const REVEAL_DURATION = 0.8;
+const EXIT_DURATION = 0.55;
 
 function BeliefScrollTextItem({
   phrase,
   index,
-  isActive,
 }: {
   phrase: string;
   index: number;
-  isActive: boolean;
 }) {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const phraseRef = useRef<HTMLDivElement | null>(null);
   const { shouldReduceMotion } = useBeliefsScrollContext();
 
-  const variants = {
-    hidden: {
-      opacity: 0,
-      y: shouldReduceMotion ? 0 : 18,
-      filter: shouldReduceMotion ? 'none' : 'blur(6px)',
-    },
-    visible: {
-      opacity: 1,
-      y: 0,
-      filter: 'blur(0px)',
-      transition: {
-        duration: MOTION_TOKENS.duration.bg,
-        ease: MOTION_TOKENS.ease.ghost,
+  useEffect(() => {
+    const el = phraseRef.current;
+    const section = sectionRef.current;
+    if (!el || !section) return;
+
+    if (shouldReduceMotion) {
+      el.style.opacity = '1';
+      el.style.transform = 'none';
+      el.style.filter = 'none';
+      return;
+    }
+
+    el.style.opacity = '0';
+    el.style.transform = 'translateY(18px)';
+    el.style.filter = 'blur(6px)';
+
+    const stop = inView(
+      section,
+      () => {
+        animate(
+          el,
+          { opacity: 1, transform: 'translateY(0px)', filter: 'blur(0px)' },
+          { duration: REVEAL_DURATION, ease: GHOST_EASE_AMBIENT }
+        );
+
+        return () => {
+          animate(
+            el,
+            { opacity: 0, transform: 'translateY(-18px)', filter: 'blur(6px)' },
+            { duration: EXIT_DURATION, ease: GHOST_EASE_AMBIENT }
+          );
+        };
       },
-    },
-    exit: {
-      opacity: 0,
-      y: shouldReduceMotion ? 0 : -18,
-      filter: shouldReduceMotion ? 'none' : 'blur(6px)',
-      transition: { duration: MOTION_TOKENS.duration.textOut },
-    },
-  };
+      { amount: 0.35, margin: '-15% 0px -15% 0px' }
+    );
+
+    return () => stop();
+  }, [shouldReduceMotion]);
 
   return (
     <section
+      ref={sectionRef}
       data-index={index}
       className="belief-scroll-section relative flex w-full snap-center items-end justify-center pb-[20vh] md:items-center md:justify-start md:pb-0"
       style={{ height: BELIEF_LAYOUT.phraseSectionHeight }}
     >
       <Container style={{ zIndex: Z_INDEX.beliefs.scrollText }}>
-        <m.div
+        <div
+          ref={phraseRef}
           data-testid="belief-phrase"
-          data-active={isActive}
-          data-animation-contract="viewport-y-opacity"
-          initial="hidden"
-          animate={isActive ? 'visible' : 'exit'}
-          variants={variants}
-          className="mx-auto max-w-[calc(100vw-2rem)] px-6 text-center will-change-transform md:ml-0 md:max-w-[38vw] md:text-left lg:max-w-[34vw]"
+          data-animation-contract="inview-y-opacity-blur"
+          className="mx-auto max-w-[calc(100vw-2rem)] px-6 text-center will-change-[transform,opacity,filter] md:ml-0 md:max-w-[38vw] md:text-left lg:max-w-[34vw]"
         >
           <h2 className="text-[clamp(2rem,8vw,3rem)] md:text-[clamp(2.8rem,5.8vw,6.3rem)] font-h1 font-bold italic text-blueAccent">
             {phrase}
           </h2>
-        </m.div>
+        </div>
       </Container>
     </section>
   );
@@ -81,11 +99,7 @@ export function BeliefScrollText() {
         opacity: shouldReduceMotion ? 1 : phrasesOpacity,
       }}
     >
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-      >
+      <span aria-live="polite" aria-atomic="true" className="sr-only">
         {BELIEF_PHRASES[activePhraseIndex]}
       </span>
 
@@ -100,7 +114,6 @@ export function BeliefScrollText() {
           key={phrase.id}
           index={index}
           phrase={phrase.text}
-          isActive={index === activePhraseIndex}
         />
       ))}
 


### PR DESCRIPTION
## Summary

Aligns the `06-O-QUE-ME-MOVE` section (`/sobre`) with the approved V5 blueprint and the canonical Motion `inView + animate` tutorial pattern. Fixes the broken climax under reduced-motion, the unconditional WebGL invalidate loop, the duplicated color source, and the conflicting phrase activation logic.

## What changed

### Phase 1 — Critical (commit `e96f570f1`)
- **GhostModel.tsx** — drop unconditional `invalidate()` inside `useFrame`; remove `usePointerParallax` import/use. Canvas re-renders only on scroll change and scene load (`frameloop="demand"` honored).
- **BeliefBackground.tsx** — `prefers-reduced-motion` no longer forces Deep Void. Final lock at `scrollProgress >= 0.82` reaches `#0048ff` regardless (snap with `duration: 0` when reduced).

### Phase 2 — Best practices (commits `e96f570f1` + `ad4e3b748`)
- **BeliefBackground.tsx** — replaced continuous `useTransform` with `animate()` + `inView('.belief-scroll-section')`, bidirectional cleanup, `GHOST_EASE_AMBIENT [0.17, 0.55, 0.55, 1]`. Single source of truth via `BELIEF_BACKGROUND_STOPS`.
- **BeliefManifesto.tsx** — lines now rendered via `SplitGhostText`, reveal gated by `isClimax` (0.56 → 0.72).
- **BeliefScrollText.tsx** — drops the `useInView` vs `scrollYProgress` race; one phrase active per window via `activePhraseIndex`. Migrated to canonical Motion tutorial pattern: `inView(el, () => { animate(...); return () => animate(...); })`.

### Phase 3 — A11y / Performance
- **GhostSceneFallback.tsx** — abstract blob replaced with Ghost silhouette SVG; exposes `data-ghost-scene` so layer assertions still pass.
- **BeliefFixedHeader.tsx** — header carries an SR-friendly `aria-label`; `aria-hidden` moved onto the decorative wrapper only.
- **BeliefBackground.tsx** — drops permanent `willChange: 'background-color'`.
- **app/sobre/loading.tsx** — `animate-pulse` gated by `motion-safe:` variant.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — only pre-existing warnings
- Browser preview probed across 5 scroll checkpoints (`0.15 / 0.35 / 0.55 / 0.75 / 0.92`):
  - Background sequence: `void → blue → purple → blue → pink → blue` ending at `rgb(0, 72, 255)`.
  - Exactly one `[data-testid="belief-phrase"]` reports `opacity: 1` per window.
  - `data-ghost-scene` z-index `70` > `data-belief-manifesto` z-index `50`.
  - Manifesto `aria-label="ISSO É GHOST DESIGN"` rendered via `SplitGhostText`.

## Test plan

- [ ] Scroll the `/sobre` page and observe the cromatic transition in both default and `prefers-reduced-motion` modes.
- [ ] Confirm final viewport is solid `#0048ff` with white `ISSO É / GHOST / DESIGN` and Ghost layered above.
- [ ] Run `npx playwright test test/e2e/about-beliefs.spec.ts` (not executed in this session).
- [ ] Verify no regression in WebGL FPS or invalidate loop on Chrome DevTools Performance.

## Notes for reviewers

- Server Component status of `app/sobre/page.tsx` preserved (no `'use client'` introduced).
- GSAP not added — Motion already covers the `inView + cleanup` pattern. Canonical GSAP scaffold remains available if a future pin/scrub scenario demands it.
- Local `main` branch still carries these 2 commits; reset to `origin/main` after merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)