### PR TITLE
fix: Ghost desktop position + BeliefScrollText hydration + ease types

### DIFF
--- a/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/ABOUT-BIEFS-DETALAHAMENTO/AJUSTES_IMPLEMENTADOS.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/ABOUT-BIEFS-DETALAHAMENTO/AJUSTES_IMPLEMENTADOS.md
@@ -48,20 +48,19 @@ blur: 0 → 10px
 ```typescript
 // Posição: SEMPRE NO RODAPÉ DA SESSÃO, CENTRALIZADO
 
-// Entrada: da DIREITA para o centro
-x: +24 → 0  // (não usar 100%, usar valor pequeno)
+// Entrada: da ESQUERDA para o centro
+x: -48 → 0
 opacity: 0 → 1
-blur: 10px → 0
 
 // Permanência: estável no rodapé
 
-// Saída: do centro para a ESQUERDA
-x: 0 → -24
+// Saída: de volta para a ESQUERDA
+x: 0 → -48
 opacity: 1 → 0
-blur: 0 → 10px
 
 // IMPORTANTE: NÃO usar `y` no mobile (sem movimento vertical)
 // Quebra de linha: só quando necessário (texto centralizado)
+// Referência: blueprint 06-O-QUE-ME-MOVE-blueprint-atualizado.md §10
 ```
 
 ---

--- a/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/ABOUT-BIEFS-DETALAHAMENTO/START_HERE.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/ABOUT-BIEFS-DETALAHAMENTO/START_HERE.md
@@ -20,7 +20,7 @@ A sessão "About Beliefs" (O Que Me Move) é uma seção emocional do portfólio
 
 **Mobile:**
 
-- ✅ Texto entra da **DIREITA** e sai pela **ESQUERDA** (horizontal)
+- ✅ Texto entra da **ESQUERDA** e sai pela **ESQUERDA** (horizontal, x: -48 → 0 → -48)
 - ✅ Texto fica no **RODAPÉ**, centralizado
 - ✅ Ghost à **ESQUERDA**
 

--- a/src/components/sobre/3d/GhostModel.tsx
+++ b/src/components/sobre/3d/GhostModel.tsx
@@ -163,6 +163,7 @@ export function GhostModel({
   pointerY,
 }: GhostModelProps) {
   const groupRef = useRef<THREE.Group>(null);
+  const initialized = useRef(false);
 
   useFrame((state: any) => {
     if (!groupRef.current) return;
@@ -194,21 +195,30 @@ export function GhostModel({
     const px = shouldReduceMotion || isMobile ? 0 : pointerX.get();
     const py = shouldReduceMotion || isMobile ? 0 : pointerY.get();
 
-    // Dynamic positioning
-    // Desktop: Ghost stays RIGHT (1.0) and drifts toward center (0.3) at climax
-    // Mobile: Ghost stays LEFT (-0.8) and centers at climax
+    // Desktop: Ghost RIGHT (1.0), drifts to center (0.3) at climax
+    // Mobile: Ghost LEFT (-0.8), centers at climax
     const targetX = isMobile
       ? isClimax
         ? 0
-        : -0.8 // Mobile: LEFT
+        : -0.8
       : isClimax
-        ? 0.3 + px * 0.15 // Desktop climax: drifts toward center
-        : 1.0 + px * 0.3; // Desktop default: RIGHT
+        ? 0.3 + px * 0.15
+        : 1.0 + px * 0.3;
 
     const targetY = isMobile ? (isClimax ? -0.35 : -0.15) : 0.0 + py * 0.25;
 
     const baseScale = isMobile ? 0.48 : 0.72;
     const targetScale = baseScale * scaleBoost;
+
+    // Snap on first frame: frameloop="demand" fires frames only per scroll/mousemove event,
+    // so lerp from x=0 takes many events to converge — ghost appears centered until then.
+    if (!initialized.current) {
+      groupRef.current.position.x = targetX;
+      groupRef.current.position.y = targetY;
+      groupRef.current.scale.setScalar(targetScale);
+      initialized.current = true;
+    }
+
     const lerpAlpha = 0.08;
 
     groupRef.current.position.x = THREE.MathUtils.lerp(

--- a/src/components/sobre/beliefs/BeliefBackground.tsx
+++ b/src/components/sobre/beliefs/BeliefBackground.tsx
@@ -39,7 +39,7 @@ export function BeliefBackground() {
           { backgroundColor: color },
           {
             duration: beliefMotion.backgroundDuration,
-            ease: beliefMotion.referenceEase as any,
+            ease: beliefMotion.referenceEase as [number, number, number, number],
           }
         );
 

--- a/src/components/sobre/beliefs/BeliefScrollText.tsx
+++ b/src/components/sobre/beliefs/BeliefScrollText.tsx
@@ -19,14 +19,16 @@ export function BeliefScrollText() {
       '#o-que-me-move [data-belief-phrase]',
       (el) => {
         const element = el as HTMLElement;
+
         if (shouldReduceMotion) {
-          element.style.opacity = '1';
-          return () => {
-            element.style.opacity = '0';
-          };
+          const controls = animate(
+            element,
+            { opacity: 1, x: 0 },
+            { duration: 0.16, ease: 'ease-out' }
+          );
+          return () => controls.stop();
         }
 
-        // Entrance: from left — desktop -100, mobile -48
         const enterX = isMobile ? -48 : -100;
 
         const enterControls = animate(
@@ -34,19 +36,18 @@ export function BeliefScrollText() {
           { opacity: 1, x: [enterX, 0] },
           {
             duration: beliefMotion.textRevealDuration,
-            ease: beliefMotion.referenceEase as any,
+            ease: beliefMotion.referenceEase as [number, number, number, number],
           }
         );
 
         return () => {
           enterControls.stop();
-
           animate(
             element,
             { opacity: 0, x: enterX },
             {
               duration: beliefMotion.textExitDuration,
-              ease: beliefMotion.referenceEase as any,
+              ease: beliefMotion.referenceEase as [number, number, number, number],
             }
           );
         };
@@ -71,23 +72,11 @@ export function BeliefScrollText() {
           className="relative flex items-center"
           style={{ height: beliefLayout.phraseSectionHeight }}
         >
-          <div
-            className={[
-              'pointer-events-none',
-              isMobile
-                ? 'fixed bottom-[20vh] left-1/2 w-[min(86vw,28rem)] -translate-x-1/2 text-center'
-                : 'ml-[clamp(1.5rem,6vw,6rem)] max-w-[38vw] text-left',
-            ].join(' ')}
-          >
+          <div className="pointer-events-none ml-[clamp(1.5rem,6vw,6rem)] max-w-[38vw] text-left max-md:fixed max-md:bottom-[20vh] max-md:left-1/2 max-md:ml-0 max-md:w-[min(86vw,28rem)] max-md:-translate-x-1/2 max-md:text-center">
             <p
               data-belief-phrase
-              className="select-none font-h1 font-bold italic leading-[1.05] tracking-[-0.03em] opacity-0 will-change-transform"
-              style={{
-                color: beliefColors.blueAccent,
-                fontSize: isMobile
-                  ? 'clamp(2rem, 8vw, 3rem)'
-                  : 'clamp(2.8rem, 5.8vw, 6.3rem)',
-              }}
+              className="select-none font-h1 text-[clamp(2.8rem,5.8vw,6.3rem)] font-bold italic leading-[1.05] tracking-[-0.03em] opacity-0 will-change-transform max-md:text-[clamp(2rem,8vw,3rem)]"
+              style={{ color: beliefColors.blueAccent }}
             >
               {phrase.text}
             </p>


### PR DESCRIPTION
## Summary

- **Ghost centered on desktop**: `frameloop="demand"` + lerp alpha `0.08` required ~12 scroll events to converge from `x=0` to `x=1.0`. Added `initialized` ref — snaps position/scale on first `useFrame`, lerps smoothly from there.
- **BeliefScrollText hydration mismatch**: JS `isMobile` gating CSS classNames and `fontSize` caused SSR/client render divergence. Replaced with Tailwind `max-md:` responsive variants.
- **shouldReduceMotion path broken**: Was setting `element.style.opacity` directly (bypassing Motion). Now uses `animate()` with `controls.stop()` cleanup — consistent with the rest of the animation system.
- **Ease cast cleanup**: `as any` → `as [number, number, number, number]` in `BeliefBackground` and `BeliefScrollText`. Matches the `EasingTuple` type already declared in `motion.ts`.
- **Docs corrected**: `AJUSTES_IMPLEMENTADOS.md` and `START_HERE.md` said mobile phrases enter from the RIGHT (`x: +24`). Blueprint §10 and implementation use LEFT (`x: -48`). Fixed both docs.

## Test plan

- [ ] Desktop: Ghost appears on the right side immediately on scroll into section (no slow drift from center)
- [ ] Mobile: Phrases appear at bottom of viewport, enter/exit horizontally from left
- [ ] Reduced motion: Phrases still appear/disappear (via `animate()`, not direct style)
- [ ] No hydration mismatch warnings in console on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)