### PR TITLE
Fix /sobre origin image loader and align What Moves Me scope

### DIFF
--- a/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/walkthrough.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/walkthrough.md
@@ -1,200 +1,108 @@
-# Walkthrough — 06-O-QUE-ME-MOVE Redesign v2
+# Walkthrough — 06-O-QUE-ME-MOVE + Origin Images Regression
 
-> **Data de implementação:** 2026-05-17
-> **Branch:** worktree-o-que-me-move-redesign-plan
-> **Substitui:** plano 2026-05-13 (GSAP + Ghost 3D)
-> **Status:** IMPLEMENTADO
+> Data: 2026-05-18  
+> Escopo: preservar a seção “O que me move” conforme documentação final sem animação Ghost 3D e corrigir regressão de imagens da seção ORIGEM.
 
----
+## Causa raiz
 
-## O Que Foi Feito
+1. A documentação final de `06-O-QUE-ME-MOVE` substituiu o plano antigo com GSAP + Ghost 3D por uma seção editorial com background CSS fixo e frases centralizadas. Portanto, a reintrodução de animação Ghost 3D nessa seção foi explicitamente cancelada pela aprovação humana.
+2. As imagens da seção ORIGEM usavam chaves de asset divergentes em `SITE_ASSET_KEYS.about.originImages` (`about.origin.about.origin_image.*`), enquanto a fonte exportada do projeto registra `about.origin_image.*`.
+3. Quando a URL de fallback era local (`/site.assets/about/origin/...`), `DynamicAssetImage` ainda passava `supabaseLoader` para `next/image`. Para caminhos locais, o loader retornava a URL sem aplicar `width`, disparando `next-image-missing-loader-width`.
 
-Redesign completo da seção `06-O-QUE-ME-MOVE`. Removido Ghost 3D (R3F canvas) e GSAP. Substituído por background CSS shade fixo e 6 frases centralizadas controladas por Framer Motion scroll.
+## Arquivos alterados
 
----
+- `src/config/site-assets.ts`
+  - Corrigidas as quatro chaves de `about.originImages` para os nomes reais registrados no export de assets.
+- `src/components/ui/shared/DynamicAssetImage.tsx`
+  - O loader Supabase agora só é aplicado para URLs remotas transformáveis.
+  - Caminhos locais, `data:` e `blob:` usam o comportamento nativo do `next/image`, eliminando o contrato inválido de loader sem `width`.
+- `docs/implementation_plan.md`
+  - Registrada a ressalva humana pós-aprovação: sem animação Ghost 3D em `06-O-QUE-ME-MOVE`.
+- `docs/task.md`
+  - Atualizadas T10/T11 para refletir a decisão de não montar WebGL nessa seção.
+- `.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/walkthrough.md`
+  - Atualizado este walkthrough com causa, decisões, validações e riscos.
 
-## Arquitetura Final
+## O que foi preservado/restaurado
 
-```
-AboutBeliefs.tsx
-  ├── WhatMovesMeBackground    (CSS shade, position:fixed, aria-hidden)
-  └── BeliefScrollText         (sticky top-0 h-dvh, scroll-driven)
-        └── WhatMovesMePhrase  (por frase: MotionValues, useReducedMotion)
-```
+- A seção “O que me move” permanece alinhada à documentação final:
+  - sem Ghost 3D renderizando;
+  - sem Canvas/WebGL;
+  - background CSS shade fixo;
+  - seis frases centralizadas controladas por scroll;
+  - frase final com `GHOST` em Ghost Blue `#0048ff`.
+- A seção ORIGEM mantém o uso de `DynamicAssetImage`, mas com chaves corretas e sem loader custom em fallback local.
 
-### Fluxo de dados
+## Proteção do Ghost 3D
 
-```
-sectionRef (AboutBeliefs)
-  → BeliefScrollText.useScroll({ target: sectionRef })
-  → scrollYProgress (0→1)
-  → 6 × useTransform(scrollYProgress, bands, [0,1,1,0])
-  → WhatMovesMePhrase(opacity, y, filter)
-```
+- Nenhum arquivo em `src/components/sobre/3d/*` foi removido.
+- A seção `AboutBeliefs` não reintroduz `GhostScene`, respeitando a documentação final e a ressalva humana.
+- WebGL permanece disponível no projeto para outros contextos, mas não participa de `06-O-QUE-ME-MOVE`.
 
----
+## Correção do loader `next/image`
 
-## Arquivos Criados
-
-| Arquivo                                                   | Função                                                                                       |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `src/components/sobre/beliefs/what-moves-me.constants.ts` | WHAT_MOVES_ME_PHRASES, GHOST_SHADE_COLORS, GHOST_EASE, PHRASE_COUNT, SECTION_HEIGHT_VH, BAND |
-| `src/components/sobre/beliefs/WhatMovesMeBackground.tsx`  | Background CSS fixo: 3 radial-gradients + grade + vinheta                                    |
-| `src/components/sobre/beliefs/WhatMovesMePhrase.tsx`      | Frase individual com MotionValues + useReducedMotion                                         |
-
-## Arquivos Modificados
-
-| Arquivo                                             | Mudança                                                                                                                                        |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/components/sobre/sections/AboutBeliefs.tsx`    | Reescrito: removidos GhostScene, GSAP, BeliefsScrollProvider, BeliefBackground, BeliefOverlay, BeliefFixedHeader, BeliefManifesto (-70 linhas) |
-| `src/components/sobre/beliefs/BeliefScrollText.tsx` | Reescrito: GSAP/left-aligned/context → Framer Motion/centrado/sectionRef prop                                                                  |
-| `src/config/beliefTokens.ts`                        | Adicionados re-exports das constantes novas                                                                                                    |
-
-## Arquivos Preservados (não tocados)
-
-`src/components/sobre/3d/*`, `BeliefBackground.tsx`, `BeliefFixedHeader.tsx`, `BeliefManifesto.tsx`, `BeliefOverlay.tsx`, `SplitTextMotion.tsx`, `BeliefsScrollContext.tsx`, `src/hooks/useBeliefsScroll.ts`
-
----
-
-## Scroll Logic
-
-`BAND = 1 / 6 ≈ 0.1667` — cada frase ocupa 1/6 do progresso total.
-
-Para frase `i` (0-indexed):
-
-| Ponto       | Fórmula                             | Valor (i=0) |
-| ----------- | ----------------------------------- | ----------- |
-| fadeInStart | `i * BAND`                          | 0.000       |
-| fadeInEnd   | `i * BAND + BAND * 0.22`            | 0.037       |
-| peakEnd     | `(i+1) * BAND - BAND * 0.22`        | 0.130       |
-| fadeOutEnd  | `(i+1) * BAND` (ou 1.1 para última) | 0.167       |
-
-Valores animados:
-
-- `opacity`: `[0, 1, 1, 0]`
-- `y`: `[18, 0, 0, -12]` px
-- `filter`: `['blur(8px)', 'blur(0px)', 'blur(0px)', 'blur(8px)']`
-
-A frase 6 (emphasis) tem `fadeOutEnd = 1.1` — não desaparece ao chegar ao fim da seção.
-
----
-
-## Frases
-
-```
-1. Acredito que design\né uma linguagem.
-2. Que sistemas\ncriam cultura.
-3. Que cada escolha visual\ncarrega intenção.
-4. Que beleza\né estratégia.
-5. Que forma\nsegue propósito.
-6. ISSO É\nGHOST\nDESIGN.  ← emphasis:true, GHOST em #0048ff
-```
-
----
-
-## Background CSS
-
-Camadas (de frente para trás):
-
-1. Vinheta: `radial-gradient(ellipse 100% 100% at 50% 50%, transparent 30%, #040013cc 100%)`
-2. Grade: `repeating-linear-gradient(90deg) + repeating-linear-gradient(0deg)` em Ghost Blue opacidade mínima
-3. Glow azul central: `radial-gradient(ellipse 80% 60% at 50% 50%, #0048ff22)`
-4. Glow roxo inferior-esquerdo: `radial-gradient(ellipse 50% 40% at 20% 80%, #8705f218)`
-5. Glow ciano superior-direito: `radial-gradient(ellipse 40% 30% at 80% 20%, #4fe6ff10)`
-6. Base: `#040013`
-
-Zero JavaScript. Zero `requestAnimationFrame`. Zero WebGL.
-
----
-
-## Acessibilidade
-
-- `<section aria-labelledby="o-que-me-move-title">` + `<h2 className="sr-only">`
-- `WhatMovesMeBackground` tem `aria-hidden="true"`
-- `WhatMovesMePhrase` tem `aria-label={phrase.text.replace(/\n/g, ' ')}` no `m.div`
-- Spans internos do `<p>` têm `aria-hidden="true"` (evita duplicação no screen reader)
-- Container `aria-live="polite"` em `BeliefScrollText`
-- Contraste `#fcffff` / `#040013` ≥ 12:1 (AAA)
-
----
-
-## Reduced Motion
+Estratégia aplicada:
 
 ```tsx
-const prefersReducedMotion = useReducedMotion(); // motion/react
-
-style={{
-  opacity,                                        // preservado (aceitável)
-  y: prefersReducedMotion ? 0 : y,               // sem translateY
-  filter: prefersReducedMotion ? 'none' : filter, // sem blur
-}}
+loader={shouldUseSupabaseLoader ? supabaseLoader : undefined}
 ```
 
----
+Critério:
 
-## Como Testar Localmente
+- usa `supabaseLoader` apenas quando `finalUrl` não é local (`/`), `data:` ou `blob:`;
+- deixa `next/image` tratar caminhos locais de `public/site.assets` nativamente;
+- mantém o loader width-aware para URLs Supabase remotas.
 
-```bash
-cd PORTFOLIO-DANILO-FINAL
-pnpm dev
-# Navegar para /sobre
-# Scrollar até seção "O que me move"
-# Verificar: 6 frases centralizadas, aparecem/somem em scroll
-# Verificar: frase 6 GHOST em azul #0048ff, sem canvas WebGL
-```
+## Paths Supabase/local auditados
 
-### Testar Reduced Motion
+| Seção | Asset lógico | Path local esperado | Bucket | Path Supabase esperado | Evidência local | Status externo |
+| --- | --- | --- | --- | --- | --- | --- |
+| ORIGEM | Imagem 1 | `/site.assets/about/origin/about.origin_image.1.webp` | `site-assets` | `about/origin/about.origin_image.1.webp` | existe em `public/site.assets` | bloqueado por proxy/envoy 403 |
+| ORIGEM | Imagem 2 | `/site.assets/about/origin/about.origin_image.2.webp` | `site-assets` | `about/origin/about.origin_image.2.webp` | existe em `public/site.assets` | bloqueado por proxy/envoy 403 |
+| ORIGEM | Imagem 3 | `/site.assets/about/origin/about.origin_image.3.webp` | `site-assets` | `about/origin/about.origin_image.3.webp` | existe em `public/site.assets` | bloqueado por proxy/envoy 403 |
+| ORIGEM | Imagem 4 | `/site.assets/about/origin/about.origin_image.4.webp` | `site-assets` | `about/origin/about.origin_image.4.webp` | existe em `public/site.assets` | bloqueado por proxy/envoy 403 |
 
-No macOS: Sistema > Acessibilidade > Monitor > Reduzir movimento
-No DevTools: Rendering > Emulate prefers-reduced-motion: reduce
+Observação: o ambiente não expôs Supabase MCP e o acesso HTTP direto ao domínio Supabase retornou bloqueio do túnel (`CONNECT tunnel failed, response 403`). A validação operacional confiável neste ambiente foi o mirror local versionado em `public/site.assets` e o export `src/config/site-assets.json`.
 
----
+## Evidências de terminal
 
-## Rollback
+- `git show 43def5ca^:src/components/sobre/sections/AboutBeliefs.tsx` confirmou que o commit `43def5ca` removeu a montagem antiga do Ghost 3D.
+- `.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/06-O-QUE-ME-MOVE-FINAL.md` confirma que a versão final documentada remove Ghost 3D e GSAP da seção.
+- `find public/site.assets/about/origin` confirmou os quatro `.webp` locais.
+- `node` sobre `src/config/site-assets.json` confirmou os quatro registros `about.origin_image.{1..4}`.
 
-```bash
-git log --oneline -10
+## Evidências visuais
 
-git checkout <sha-antes-do-redesign> -- \
-  src/components/sobre/sections/AboutBeliefs.tsx \
-  src/components/sobre/beliefs/BeliefScrollText.tsx \
-  src/config/beliefTokens.ts
+Validação visual automatizada via navegador não foi concluída neste ambiente antes deste registro. Checklist manual esperado em `pnpm dev`:
 
-git rm src/components/sobre/beliefs/what-moves-me.constants.ts
-git rm src/components/sobre/beliefs/WhatMovesMeBackground.tsx
-git rm src/components/sobre/beliefs/WhatMovesMePhrase.tsx
-```
+1. abrir `/sobre`;
+2. navegar até ORIGEM e confirmar quatro imagens sem erro `next-image-missing-loader-width`;
+3. navegar até “O que me move” e confirmar seção sem Canvas/WebGL/Ghost 3D animado;
+4. confirmar frases centralizadas, background Ghost shade e frase final com `GHOST` em `#0048ff`.
 
----
+## Validações executadas
 
-## Decisões Técnicas
+- Inspeção de histórico Git para identificar remoção do Ghost 3D.
+- Inspeção de `.context` para reconciliar intenção atual versus plano antigo.
+- Inspeção de `next.config.mjs` para confirmar `remotePatterns` Supabase.
+- Inspeção de `src/config/site-assets.json` e `public/site.assets/about/origin`.
+- Correções programáticas em `src/config/site-assets.ts` e `DynamicAssetImage.tsx`.
 
-| Decisão                    | Escolha                                     | Motivo                                                     |
-| -------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
-| Background                 | CSS puro                                    | Spec pede "shade fixo" — sem animação contínua, zero WebGL |
-| Animação                   | Framer Motion useScroll/useTransform        | Substitui GSAP ScrollTrigger; já no bundle                 |
-| Frases                     | 1 useScroll no pai, MotionValues como props | Evita N listeners; `useTransform` é lazy                   |
-| `useTransform` no `.map()` | Seguro                                      | Array de tamanho fixo 6 — hooks nunca variam               |
-| Última frase               | `fadeOutEnd = 1.1`                          | Não desaparece no fim — climax visual permanente           |
-| Ghost 3D                   | Arquivos preservados                        | Pode ser reutilizado em outras seções                      |
+## Validações finais executadas após a correção
 
----
+- `pnpm run lint` passou. O ambiente emitiu apenas warning de engine porque o projeto pede Node 22 e o container usa Node 20.20.2.
+- `pnpm run typecheck` passou. Mesmo warning de engine do ambiente.
+- `pnpm run build` passou. O build usou fallback quando Supabase ficou inacessível por rede (`ENETUNREACH`) e não falhou.
+- `pnpm test` passou: 37 suites e 250 testes.
+- `pnpm run dev` + `curl http://127.0.0.1:3000/sobre` retornou HTTP 200 e o log não apresentou `next-image-missing-loader-width`.
+- Screenshot automatizado via Playwright foi tentado, mas Chromium não abriu por dependência nativa ausente no container (`libatk-1.0.so.0`).
 
-## Critérios de Aceite
+## Riscos remanescentes
 
-```
-[x] Sem Ghost 3D renderizando
-[x] Background CSS shade fixo, cores do projeto
-[x] 6 frases ordem correta
-[x] Frases centralizadas desktop e mobile
-[x] Frase 6: emphasis, GHOST em #0048ff, font maior
-[x] Scroll forward: frases aparecem e somem
-[x] Scroll reverso: frases reaparecem
-[x] Reduced motion: sem y, sem filter
-[x] Sem scale/rotate/bounce/translateX
-[x] BeliefManifesto e BeliefFixedHeader NÃO montados
-[x] Arquivos 3d/* intactos
-[x] pnpm lint: PASS
-[x] pnpm typecheck: PASS
-[x] pnpm build: PASS
-```
+- Se o banco `site_assets` em produção ainda contiver keys divergentes, os fallbacks locais continuarão protegendo o layout, mas a origem remota deve ser reconciliada no Supabase Dashboard/MCP.
+- O ambiente atual bloqueou auditoria HTTP real do Supabase; a verificação externa precisa ser repetida em rede sem proxy restritivo.
+- `pnpm build` pode atualizar `public/build-info.json`, que já aparece como artefato gerado no workspace.
+
+## Recomendação sobre blueprints
+
+Manter `06-O-QUE-ME-MOVE-FINAL.md` como fonte de verdade atual. Qualquer retorno de Ghost 3D nessa seção deve exigir novo blueprint e aprovação explícita, porque conflita com a documentação final aprovada.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,143 +1,104 @@
-# Ghost System — Implementation Plan
-**Data:** 2026-05-17 | **Projeto:** portfoliodanilo.com | **Status:** AGUARDANDO APROVAÇÃO HUMANA
+# implementation_plan.md
+
+## 1) Resumo executivo
+Plano de restauração de regressão da rota `/sobre` com foco em: (a) recuperar a intenção visual da seção **“O que me move”**, (b) reintroduzir com segurança o bloco 3D Ghost/WebGL no client boundary, (c) corrigir erro `next-image-missing-loader-width`, e (d) reconciliar paths `site.assets` vs `site-assets` entre código, assets locais e Supabase.
+
+## 2) Causa provável da regressão
+- Regressão funcional/visual introduzida em alterações recentes na família de componentes da seção Beliefs (`AboutBeliefs*`), com potencial remoção/substituição de composição 3D por estrutura textual.
+- Erro de `next/image` indica uso de `loader` custom sem contrato completo (`width` ausente no retorno URL).
+- Paths locais com prefixo `/site.assets/...` coexistem com nomenclatura de bucket `site-assets`, elevando risco de resolução inconsistente.
+
+## 3) Diferença entre estado esperado e estado atual
+**Esperado:** seção com camadas Ghost (atmosfera + profundidade + texto), presença 3D não bloqueante, fallback seguro, imagens ORIGEM estáveis.
+**Atual:** relato de perda do 3D Ghost, seção textualizada, warnings de `next/image` e suspeita de path inconsistente.
+
+## 4) Mapa da seção “O que me move”
+- Entrada da seção na rota: `src/app/sobre/page.tsx` (`AboutBeliefs` dentro de `SectionErrorBoundary`).
+- Pontos de inspeção: `src/components/sobre/sections` e subcomponentes Beliefs (background/overlay/manifesto/scroll/canvas/fallback).
+- Dependências: motion tokens, z-index tokens, hooks de viewport/motion gate.
+
+## 5) Mapa dos componentes 3D Ghost
+- Assets locais detectados: `public/models/ghost.glb`, `public/models/ghost-transformed.glb`, `public/site.assets/3d/ghost-v1.glb`, fallbacks jpg/png.
+- Alvos de inspeção: componentes com `Canvas`, R3F, Drei, loaders GLTF e qualquer `dynamic(..., { ssr:false })`.
+- Verificar acoplamento com desempenho (IntersectionObserver, invalidation RAF, lazy mount).
+
+## 6) Diagnóstico do erro `next-image-missing-loader-width`
+Hipótese primária: `Image` com `loader` custom retorna URL sem parâmetro de largura. Em Next 16, loader deve receber `{ src, width, quality }` e produzir URL width-aware.
+
+## 7) Diagnóstico do warning DEP0205
+Classificado como secundário (conforme incidente). Tratar apenas como backlog técnico; não bloqueia a restauração visual/funcional da seção.
+
+## 8) Auditoria Supabase Storage via MCP
+Escopo planejado:
+- Bucket `site-assets`
+- Objetos `about/origin/about.origin_image.{1..4}.webp`
+- URL pública `storage/v1/object/public/...`
+- URL transform `storage/v1/render/image/public/...`
+- ACL pública, MIME, cache-control, CORS e status HTTP.
+
+## 9) Auditoria paths `site.assets` vs `site-assets`
+- Validar se `/site.assets/...` é caminho **local em `/public`** (válido para Next static).
+- Validar se `site-assets/...` é **bucket Supabase** (válido para URL remota pública).
+- Eliminar ambiguidade na fonte de verdade de cada seção da `/sobre`.
+
+## 10) Auditoria de `next.config.*`
+- Confirmar `images.remotePatterns`/`images.domains` para host Supabase efetivo.
+- Confirmar compatibilidade Firebase Hosting + Next image optimizer.
+- Garantir CSP `img-src`/`media-src` com host Supabase e assets usados.
+
+## 11) Estratégia de restauração visual
+1. Identificar commit/alteração que removeu/degradou o Ghost 3D.
+2. Recuperar componente original (ou equivalente já existente) sem redesign.
+3. Reaplicar layering/z-index/tokens Ghost conforme documentação de Sobre.
+4. Garantir animações permitidas (opacity/blur/translateY) com easing obrigatório.
+
+## 12) Estratégia de correção das imagens
+- Se origem for local (`public/site.assets/...`): remover loader custom na seção ORIGEM e usar `src` local puro.
+- Se origem for Supabase: usar URL pública + `remotePatterns` ou loader Supabase correto com `width` e `quality`.
+- Proibir probing runtime de extensões.
+
+## 13) Estratégia de fallback WebGL
+- Boundary client-only para Canvas (`dynamic import` com `ssr:false` quando necessário).
+- Fallback estático leve (imagem/gradiente) mantendo composição e acessibilidade.
+- Não bloquear FCP: lazy mount + viewport gate.
+
+## 14) Arquivos candidatos afetados
+- `src/app/sobre/page.tsx`
+- `src/components/sobre/**` (especialmente seção Beliefs e seção Origin)
+- `src/lib/supabase/image-loader.mjs` e utilitários de URL
+- `src/config/site-assets.*` / `src/lib/supabase/site-assets*`
+- `next.config.mjs`
+- `.context/DOCS-PORTFOLIO-PAGES/**` (sincronização de estado, se alteração em `src/` ocorrer)
+
+## 15) Riscos
+- Reintrodução de WebGL impactar LCP/FCP em devices fracos.
+- Corrigir loader sem alinhar origem real dos assets pode mascarar 404.
+- Divergência entre docs e código real de produção.
+
+## 16) Rollback
+- Estratégia Git: rollback do conjunto de commits da seção Beliefs/Origin para último estado estável.
+- Toggle por feature flag local de renderização Ghost (se já existir no código) para desativação emergencial.
+
+## 17) Validações
+- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm dev`
+- Abrir `/sobre` e validar: ausência de `next-image-missing-loader-width`, presença do Ghost 3D/fallback, imagens ORIGEM carregando, sem 404/403 críticos.
+
+## 18) Definition of Done
+Conforme gate do incidente: seção restaurada visualmente, Ghost 3D presente/seguro, erro de loader eliminado, paths reconciliados, auditoria Supabase concluída e evidências registradas em `walkthrough.md`.
 
 ---
 
-## Resumo Executivo
+## Observações de pesquisa e limitações
+- **Repositório local foi auditado** para estrutura, assets, configs e rota `/sobre`.
+- **Vector Store `vs_69520b1fb834819197e445db9aab8d69` não está disponível neste ambiente** via ferramenta exposta; será tratado como bloqueio parcial até conector ser disponibilizado.
+- **Consulta Context7/Supabase MCP**: planejada na fase de execução após aprovação humana.
 
-Auditoria estrutural completa identificou dois vetores críticos de problema: (1) versionamento indevido de 11.940 arquivos não-fonte no repositório, causando o aviso de truncamento do GitHub para 1.000 arquivos por diretório; (2) três violações das regras do Ghost Design System no código-fonte ativo.
+## Atualização pós-aprovação — ressalva humana (2026-05-18)
 
-O repositório tem **12.281 arquivos rastreados**, mas apenas **341 são código-fonte real** (`src/`). A razão de ruído para sinal é de **35:1** — o inverso do que deveria ser.
+A aprovação humana alterou o escopo visual da seção `06-O-QUE-ME-MOVE`: a seção **não deve mais usar animação com Ghost 3D**, porque a documentação final de `.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/06-O-QUE-ME-MOVE-FINAL.md` substitui o plano antigo de GSAP + WebGL por uma composição editorial minimalista com CSS shade fixo e frases centralizadas.
 
----
+Decisão operacional:
+- Manter `src/components/sobre/sections/AboutBeliefs.tsx` no modelo documentado atual: sem `GhostScene`, sem `Canvas`, sem GSAP e sem WebGL nessa seção.
+- Preservar os componentes `src/components/sobre/3d/*` sem reintroduzi-los em `AboutBeliefs`, para uso futuro em outras áreas se necessário.
+- Focar a execução aprovada na correção real da regressão de imagens ORIGEM: keys de assets divergentes e `next/image` recebendo loader custom para caminho local `/site.assets/...`.
 
-## Diagnóstico P0 — Incidente GitHub (Truncamento de Diretório)
-
-### Distribuição dos arquivos rastreados
-
-| Diretório | Arquivos | Tipo | Deve estar no git? |
-|-----------|----------|------|-------------------|
-| `.agent/skills/` | 6.346 | Biblioteca de skills de IA | ⚠️ Decisão de arquitetura |
-| `functions/.npm_cache/` | 2.759 | Cache npm local | ❌ NÃO |
-| `reports/` | 523 | Relatórios de auditoria gerados | ⚠️ Seletivo |
-| `.claude/` | 338 | Config Claude (plugins: 237) | ⚠️ Seletivo |
-| `.agents/` | 284 | Biblioteca de skills secundária | ⚠️ Decisão de arquitetura |
-| `docs/` | 239 | Documentação | ✅ SIM |
-| `scripts/__pycache__` + `.pyc` | 40 | Bytecode Python compilado | ❌ NÃO |
-| `graphify-out/` | 47 | Exports visuais gerados | ❌ NÃO |
-| `scratch/` | 16 | Arquivos temporários de sessão | ❌ NÃO (já no .gitignore, pré-commit) |
-| `output/` | 12 | Output temporário | ❌ NÃO |
-| **`src/` (código real)** | **341** | Código-fonte da aplicação | ✅ SIM |
-
-### Causa raiz do truncamento
-
-O GitHub mostra o aviso quando um diretório tem mais de 1.000 arquivos. Os seguintes diretórios violam esse limite:
-- `.agent/` — 6.673 arquivos (6.346 só em `skills/`)
-- `functions/` — 2.767 arquivos (2.759 em `.npm_cache/`)
-- `reports/` — 523 arquivos
-
-### Lacunas no .gitignore
-
-O `.gitignore` atual **não cobre**:
-1. `functions/.npm_cache/` — cache npm dentro de functions (2.759 arquivos não devem estar no git)
-2. `graphify-out/` — exports visuais gerados automaticamente
-3. `**/__pycache__/` e `**/*.pyc` — bytecode Python compilado
-4. `output/` — diretório de output de sessão
-5. `.agent/skills/` — decisão pendente (ver trade-offs abaixo)
-
-**Nota:** `scratch/` já está no `.gitignore`, mas os arquivos foram commitados antes da regra ser adicionada. Precisam de `git rm --cached`.
-
-### Trade-offs sobre `.agent/skills/` e `.agents/`
-
-**Manter rastreado:** A biblioteca de skills é intencional, permite colaboração e controle de versão da inteligência do agente. Custo: repositório pesado, truncamento no GitHub.
-
-**Remover do git:** Repositório limpo, GitHub funcional. Custo: a biblioteca de skills precisa ser distribuída por outro mecanismo (submodule, release artifact, ou download on-demand). Recomendação: **mover para git submodule** ou **comprimir como release artifact**.
-
-A decisão sobre `.agent/skills/` e `.agents/` requer aprovação explícita do autor.
-
----
-
-## Diagnóstico P0 — Ghost Design System
-
-### Violação 1: `rotate` em `CategoryStripe.tsx` (BLOQUEANTE)
-
-**Arquivo:** `src/components/home/portfolio-showcase/CategoryStripe.tsx:163`
-**Violação:** `rotate: isHovered ? 0 : -45`
-
-A regra do Ghost System proíbe explicitamente `rotate` como motion property (apenas `opacity`, `blur` e `translateY` são permitidos; `translateX` é aceito se documentado). O ícone `ArrowUpRight` usa rotate para indicar direção durante hover.
-
-**Solução proposta:** Substituir `rotate` por duas variantes SVG/Lucide diferentes (uma diagonal, uma vertical) comutadas via `opacity: 0/1` com easing padrão `[0.22, 1, 0.36, 1]`. Ou usar `scale` + `translateY` controlado como affordance direcional documentado. Mantém a legibilidade da UX sem violar o sistema de motion.
-
-**Risco da solução:** Baixo. Mudança é visual e localizada em um único componente.
-
-### Violação 2: Cor `purpleDetails` no hover do ícone em `CategoryStripe.tsx` (CONDICIONAL)
-
-**Arquivo:** `src/components/home/portfolio-showcase/CategoryStripe.tsx:165`
-**Violação:** `backgroundColor: isHovered ? COLORS.purpleDetails : COLORS.bluePrimary`
-
-A regra permite roxo em estados de Hover e efeitos "Glitch". Este uso específico é em `animate.backgroundColor` durante hover — tecnicamente permitido pela exceção da regra. **Não é violação**, mas precisa de documentação explícita no código indicando que é uso intencional por exceção.
-
-### Violação 3: `src/lib/supabase/image-loader.ts` ausente (AUSÊNCIA)
-
-**Arquivo esperado:** `src/lib/supabase/image-loader.ts`
-**Impacto:** Imagens do Supabase Storage sendo servidas sem otimização via `next/image`. O `next.config.mjs` já tem `remotePatterns` configurado para o host Supabase, mas sem um loader customizado, não há controle sobre transformação de imagem (width, quality, format).
-
-**Solução proposta:** Criar `src/lib/supabase/image-loader.ts` com um loader que constrói URLs do Supabase Storage com parâmetros de transformação (`width`, `quality`, `format=webp`), e registrar em `next.config.mjs` via `loaderFile`.
-
-### Violação 4: Ausência de `MotionLink` (AUSÊNCIA)
-
-**Impacto:** Links internos usam `<Link>` nativo do Next.js sem wrap de animação. A navegação client-side não tem transição de saída, quebrando a experiência "Ethereal" do Ghost System para rotas internas.
-
-**Solução proposta:** Criar `src/components/motion/MotionLink.tsx` que envolve `<Link>` com `<m.span>` de `motion/react`, aplicando `opacity: [1, 0]` na saída e delegando ao `AnimatePresence` global. Substituir usos em Header e cards de projeto.
-
----
-
-## Diagnóstico P1 — Ghost Design System
-
-### P1.1: Verificação de `scale` em componentes R3F
-
-Os usos de `scale` em `GhostModel.tsx` são propriedades Three.js (`mesh.scale`, `groupRef.current.scale.setScalar()`), não CSS motion. **Não são violações** do Ghost System — a regra de motion se aplica a Framer Motion / CSS transitions, não ao loop R3F.
-
-O único `scale` potencialmente problemático é em CSS Tailwind: `group-hover:scale-125` em `AdminShell.tsx:86` e `group-hover:scale-105` em `AssetCard.tsx:184` — ambos em contexto de admin, que opera com regras de motion relaxadas.
-
-### P1.2: Uso de vermelho em componentes
-
-Todos os usos de vermelho identificados são em contextos de admin (delete, destructivo, alerta, erro). A regra do Ghost System permite vermelho para "erro, destrutivo ou alerta sistêmico". **Sem violações.**
-
-### P1.3: Estado ativo do Header Desktop
-
-`DesktopFluidHeader.tsx` implementa `isActive` via `isNavItemActive()`, aplica `text-bluePrimary font-semibold` e `animate="active"`. A implementação está correta. Nenhuma violação detectada.
-
----
-
-## Matriz de Prioridades
-
-| ID | Prioridade | Área | Ação | Impacto | Esforço |
-|----|-----------|------|------|---------|---------|
-| R1 | P0 | Repo | Adicionar `functions/.npm_cache/` ao `.gitignore` + `git rm --cached` | Remove 2.759 arquivos do histórico futuro | Baixo |
-| R2 | P0 | Repo | Adicionar `graphify-out/` ao `.gitignore` + `git rm --cached` | Remove 47 arquivos | Baixo |
-| R3 | P0 | Repo | Adicionar `**/__pycache__/` e `**/*.pyc` ao `.gitignore` + `git rm --cached` | Remove 40 bytecode files | Baixo |
-| R4 | P0 | Repo | `git rm --cached` de `scratch/` e `output/` (já no .gitignore) | Remove 28 arquivos | Baixo |
-| R5 | P0 | Repo | **Decisão arquitetural:** `.agent/skills/` e `.agents/` — manter, gitignore, ou submodule | Remove até 6.630 arquivos | Alto (requer aprovação) |
-| G1 | P0 | Ghost | Substituir `rotate` por alternativa em `CategoryStripe.tsx:163` | Restaura conformidade de motion | Baixo |
-| G2 | P0 | Ghost | Criar `src/lib/supabase/image-loader.ts` | Performance + conformidade | Médio |
-| G3 | P1 | Ghost | Criar `src/components/motion/MotionLink.tsx` | UX de navegação | Médio |
-| G4 | P1 | Ghost | Documentar uso de `purpleDetails` em CategoryStripe como exceção intencional | Conformidade documental | Baixo |
-
----
-
-## Exposição de Secrets
-
-Auditoria nos arquivos rastreados não identificou secrets expostos. O `.gitignore` cobre `.env`, `.env.local` e credenciais. O arquivo `firebase-config.json` contém apenas config pública (apiKey de browser, projectId) — aceitável para repositório público segundo documentação Firebase.
-
----
-
-## Próximos Passos (pendentes de aprovação)
-
-1. Aprovação humana explícita com `"Aprovado"` ou `"Proceed"` para iniciar execução.
-2. Decisão específica sobre `.agent/skills/`: gitignore, submodule, ou manter.
-3. Execução em ordem: R1 → R3 → R4 → R2 → G1 → G2 → G3 → G4 → R5 (se aprovado).
-
----
-
-*Gerado por Ghost Audit Pipeline | 2026-05-17 | Auditoria estrutural completa*

--- a/docs/task.md
+++ b/docs/task.md
@@ -1,259 +1,180 @@
-# Ghost System — Task List
-**Data:** 2026-05-17 | **Status:** AGUARDANDO APROVAÇÃO HUMANA | **Branch:** `claude/exciting-thompson-JBbyz`
+# task.md
 
----
+## T01 — Localizar implementação atual “O que me move”
+- **Objetivo:** mapear árvore real da seção atual.
+- **Especialista:** Next.js App Router Specialist
+- **Arquivos prováveis:** `src/app/sobre/page.tsx`, `src/components/sobre/sections/**`
+- **MCP necessário:** não
+- **Passos:** identificar componente raiz, imports, boundaries e fallback.
+- **Validação:** mapa de componentes com responsabilidades.
+- **Critério de aceite:** origem do render da seção completamente identificada.
+- **Risco:** componentes indiretos lazy/dynamic ocultarem fluxo.
 
-> **BLOQUEIO TOTAL:** Nenhuma tarefa abaixo deve ser executada antes de aprovação humana explícita.
-> Aprovar com: `"Aprovado"` ou `"Proceed"`.
+## T02 — Localizar implementação anterior/documentação visual
+- **Objetivo:** recuperar baseline de intenção original sem redesign.
+- **Especialista:** QA Visual Regression Engineer
+- **Arquivos prováveis:** `.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/**`, `docs/SOBRE/**`, histórico git.
+- **MCP necessário:** Context7 (apenas docs técnicas externas quando necessário)
+- **Passos:** cruzar docs de Sobre com snapshots e histórico.
+- **Validação:** checklist expected vs current por bloco visual.
+- **Critério de aceite:** baseline visual/narrativa definido.
+- **Risco:** documentação divergente do código mais recente.
 
----
+## T03 — Identificar onde o 3D Ghost foi removido
+- **Objetivo:** apontar commit/arquivo/linhas da remoção.
+- **Especialista:** React+TypeScript Frontend Architect
+- **Arquivos prováveis:** componentes Beliefs/GhostScene/GhostCanvas.
+- **MCP necessário:** não
+- **Passos:** `git log`, `git blame`, diff dos componentes-chave.
+- **Validação:** evidência objetiva de remoção/substituição/comentário.
+- **Critério de aceite:** causa técnica da perda do 3D mapeada.
+- **Risco:** regressão distribuída em múltiplos commits.
 
-## FASE P0 — Higiene de Repositório (Sem risco de regressão)
+## T04 — Mapear componentes R3F/Drei/Three disponíveis
+- **Objetivo:** inventário reutilizável para restauração.
+- **Especialista:** R3F+Drei+Three Specialist
+- **Arquivos prováveis:** `src/components/**`, `src/lib/three-console.ts`, `public/models/**`.
+- **MCP necessário:** Context7
+- **Passos:** mapear Canvas, loaders, controls, materiais e fallbacks.
+- **Validação:** tabela componente -> uso -> status.
+- **Critério de aceite:** arquitetura 3D pronta para reintegração segura.
+- **Risco:** código legado com APIs deprecadas.
 
-### R1 — Remover cache npm das functions do git
-**Responsável:** Repo Architect
-**Prioridade:** CRÍTICO
-**Arquivos afetados:** `functions/.npm_cache/` (2.759 arquivos)
+## T05 — Auditar erro next/image loader sem width
+- **Objetivo:** confirmar ponto exato do contrato quebrado.
+- **Especialista:** Next.js App Router Specialist
+- **Arquivos prováveis:** seção Origin/Beliefs, `src/lib/supabase/image-loader.mjs`.
+- **MCP necessário:** Context7
+- **Passos:** localizar `loader` custom e verificar `{src,width,quality}`.
+- **Validação:** reprodução local do warning e causa raiz.
+- **Critério de aceite:** decisão técnica (corrigir/remover/unoptimized) fundamentada.
+- **Risco:** múltiplos loaders competindo.
 
-**Passos:**
-- [ ] Adicionar `functions/.npm_cache/` ao `/home/user/PORTFOLIO-DANILO-FINAL/.gitignore` (seção "Local npm/pnpm caches")
-- [ ] Adicionar `functions/.npm_cache/` ao `functions/.gitignore`
-- [ ] Executar: `git rm -r --cached functions/.npm_cache/`
-- [ ] Verificar: `git ls-files | grep "functions/.npm_cache" | wc -l` deve retornar 0
-- [ ] Validar que `functions/` ainda funciona (index.js, package.json intactos)
+## T06 — Auditar paths `/site.assets`
+- **Objetivo:** validar semântica local vs remota desses paths.
+- **Especialista:** Supabase Storage Auditor
+- **Arquivos prováveis:** `src/config/site-assets.*`, `src/lib/supabase/site-assets*`, componentes de origem.
+- **MCP necessário:** Supabase MCP
+- **Passos:** rastrear cada path da `/sobre` até origem real.
+- **Validação:** matriz path atual/esperado por seção.
+- **Critério de aceite:** ambiguidade eliminada.
+- **Risco:** normalização de path quebrar cache existente.
 
-**Rollback:** `git restore --staged functions/.npm_cache/` (desfaz o staging sem alterar arquivos locais)
+## T07 — Auditar bucket `site-assets` via Supabase MCP
+- **Objetivo:** comprovar existência e metadados dos objetos ORIGEM.
+- **Especialista:** Supabase MCP Operator
+- **Arquivos prováveis:** N/A (auditoria remota)
+- **MCP necessário:** Supabase MCP
+- **Passos:** listar objetos, checar ACL, MIME, CORS, cache e URLs públicas/render.
+- **Validação:** tabela obrigatória (seção, asset, path, bucket, existência, URL, HTTP, consumidor, ação).
+- **Critério de aceite:** diagnóstico objetivo para cada asset crítico.
+- **Risco:** credenciais MCP indisponíveis.
 
----
+## T08 — Auditar `next.config.*`
+- **Objetivo:** validar suporte de imagens remotas e CSP.
+- **Especialista:** Firebase Hosting Readiness Reviewer
+- **Arquivos prováveis:** `next.config.mjs`, `firebase.json`.
+- **MCP necessário:** Context7
+- **Passos:** revisar `images.*`, CSP `img-src`, implicações no Firebase hosting.
+- **Validação:** checklist de conformidade.
+- **Critério de aceite:** configuração suficiente para estratégia escolhida.
+- **Risco:** otimização de imagem incompatível com runtime alvo.
 
-### R2 — Remover bytecode Python compilado
-**Responsável:** Repo Architect
-**Prioridade:** CRÍTICO
-**Arquivos afetados:** 40 arquivos `.pyc` e `__pycache__/`
+## T09 — Planejar correção loader/remoção
+- **Objetivo:** definir solução única para `next/image`.
+- **Especialista:** Next.js Best Practices
+- **Arquivos prováveis:** componentes ORIGEM + loader util.
+- **MCP necessário:** Context7
+- **Passos:** escolher entre loader compatível, URL pública sem loader, ou `unoptimized` com justificativa.
+- **Validação:** warning desaparece em `/sobre`.
+- **Critério de aceite:** sem `next-image-missing-loader-width`.
+- **Risco:** regressão de performance.
 
-**Passos:**
-- [ ] Adicionar ao `.gitignore` (se não existir já):
-  ```
-  **/__pycache__/
-  **/*.pyc
-  **/*.pyo
-  ```
-- [ ] Executar: `git rm -r --cached --ignore-unmatch "**/__pycache__" "**/*.pyc" "**/*.pyo"`
-- [ ] Verificar: `git ls-files | grep ".pyc" | wc -l` deve retornar 0
-- [ ] Confirmar que scripts Python ainda executam corretamente
+## T10 — Planejar restauração do 3D Ghost
+- **Objetivo:** reintroduzir 3D conforme intenção original.
+- **Especialista:** R3F+Drei+Three Specialist
+- **Arquivos prováveis:** seção Beliefs + componentes Ghost.
+- **MCP necessário:** Context7
+- **Passos:** recuperar componente original/equivalente, ajustar layering e tokens.
+- **Validação:** presença visual do Ghost sem ruído.
+- **Critério de aceite:** seção deixa de ser textualizada e preserva atmosfera.
+- **Risco:** overdraw/z-index conflitar com manifesto.
 
-**Rollback:** Não necessário (bytecode é regenerado automaticamente na próxima execução Python)
+## T11 — Planejar fallback seguro WebGL
+- **Objetivo:** robustez em falha WebGL/dispositivo restrito.
+- **Especialista:** Performance Engineer
+- **Arquivos prováveis:** boundary da seção Beliefs, fallback assets.
+- **MCP necessário:** não
+- **Passos:** definir fallback estático, lazy mount, gate de viewport/motion.
+- **Validação:** conteúdo acessível mesmo sem WebGL.
+- **Critério de aceite:** sem quebra de layout/UX.
+- **Risco:** fallback visual descaracterizar seção.
 
----
+## T12 — Planejar validação visual desktop
+- **Objetivo:** comprovar restauração desktop.
+- **Especialista:** QA Visual Regression Engineer
+- **Arquivos prováveis:** specs e screenshots de referência.
+- **MCP necessário:** não
+- **Passos:** checklist de composição, camadas, contraste e narrativa.
+- **Validação:** comparação com docs/screenshots.
+- **Critério de aceite:** aderência Ghost Design desktop.
+- **Risco:** baseline incompleto.
 
-### R3 — Remover arquivos de sessão temporária já ignorados
-**Responsável:** Repo Architect
-**Prioridade:** ALTO
-**Arquivos afetados:** `scratch/` (16 arquivos), `output/` (12 arquivos)
+## T13 — Planejar validação visual mobile
+- **Objetivo:** comprovar restauração mobile.
+- **Especialista:** Accessibility and SEO Reviewer
+- **Arquivos prováveis:** seção `/sobre` e referências mobile.
+- **MCP necessário:** não
+- **Passos:** validar legibilidade, hierarquia, fallback e performance percebida.
+- **Validação:** checklist mobile aprovado.
+- **Critério de aceite:** sem regressão de UX mobile.
+- **Risco:** clipping/overflow em breakpoints.
 
-**Passos:**
-- [ ] Verificar que `scratch/` e `output/` estão no `.gitignore` (já confirmado)
-- [ ] Executar: `git rm -r --cached scratch/ output/`
-- [ ] Adicionar `output/` ao `.gitignore` explicitamente (atualmente não está listado)
-- [ ] Verificar: `git ls-files | grep "^scratch\|^output" | wc -l` deve retornar 0
+## T14 — Planejar validação de console
+- **Objetivo:** eliminar erros fatais/warnings críticos.
+- **Especialista:** Frontend Code Review
+- **Arquivos prováveis:** console dev/build logs.
+- **MCP necessário:** não
+- **Passos:** executar `/sobre` e coletar logs relevantes.
+- **Validação:** ausência do warning de loader width.
+- **Critério de aceite:** console limpo de erros críticos.
+- **Risco:** warnings colaterais mascararem regressão.
 
-**Rollback:** `git restore --staged scratch/ output/`
+## T15 — Planejar validação de build
+- **Objetivo:** garantir integridade de entrega.
+- **Especialista:** lint-and-validate
+- **Arquivos prováveis:** projeto inteiro.
+- **MCP necessário:** não
+- **Passos:** `pnpm lint`, `pnpm typecheck`, `pnpm build`.
+- **Validação:** comandos concluídos sem falha crítica.
+- **Critério de aceite:** gates técnicos aprovados ou limitações documentadas.
+- **Risco:** tempo alto de execução local.
 
----
+## T16 — Planejar atualização de docs
+- **Objetivo:** sincronizar `.context` após alterações em `src/`.
+- **Especialista:** Frontend Architect
+- **Arquivos prováveis:** `.context/DOCS-PORTFOLIO-PAGES/**`.
+- **MCP necessário:** não
+- **Passos:** registrar decisões e estado final da seção restaurada.
+- **Validação:** docs refletindo implementação final.
+- **Critério de aceite:** consistência código↔contexto.
+- **Risco:** drift documental em PR futuro.
 
-### R4 — Remover exports visuais gerados (`graphify-out/`)
-**Responsável:** Repo Architect
-**Prioridade:** ALTO
-**Arquivos afetados:** `graphify-out/` (47 arquivos)
+## T17 — Gerar `walkthrough.md`
+- **Objetivo:** consolidar causa raiz, mudanças, evidências e riscos.
+- **Especialista:** QA Visual Regression Engineer
+- **Arquivos prováveis:** `docs/walkthrough.md` (ou diretório padrão do projeto)
+- **MCP necessário:** não
+- **Passos:** compilar logs, checks, validações visuais e técnicas.
+- **Validação:** documento cobrindo todos os itens obrigatórios do incidente.
+- **Critério de aceite:** rastreabilidade completa da restauração.
+- **Risco:** evidências insuficientes se não capturadas durante execução.
 
-**Passos:**
-- [ ] Verificar conteúdo do diretório: `ls graphify-out/` (confirmar que são apenas exports gerados, não assets de produção)
-- [ ] Adicionar ao `.gitignore`: `graphify-out/`
-- [ ] Executar: `git rm -r --cached graphify-out/`
-- [ ] Verificar: `git ls-files | grep "^graphify-out" | wc -l` deve retornar 0
+## Atualização pós-aprovação — mudança de escopo T10/T11 (2026-05-18)
 
-**Rollback:** `git restore --staged graphify-out/`
+A ressalva humana aprovada cancela a reintrodução de animação Ghost 3D em `06-O-QUE-ME-MOVE`.
 
----
+- **T10 atualizado:** preservar a implementação documentada sem Ghost 3D na seção, validando que `AboutBeliefs` continua sem `GhostScene`, `Canvas`, `BeliefManifesto`, `BeliefFixedHeader` e GSAP.
+- **T11 atualizado:** fallback WebGL deixa de se aplicar a essa seção, porque WebGL não deve montar em `06-O-QUE-ME-MOVE`; os componentes 3D existentes permanecem preservados fora do fluxo da seção.
+- **Execução prioritária:** corrigir keys de assets da ORIGEM e remover loader custom quando `next/image` recebe caminho local `/site.assets/...`.
 
-### R5 — DECISÃO ARQUITETURAL: Biblioteca de Skills do Agente
-**Responsável:** Danilo Novais (decisão humana obrigatória)
-**Prioridade:** CRÍTICO (impacto maior)
-**Arquivos afetados:** `.agent/skills/` (6.346), `.agents/` (284) = 6.630 arquivos
-
-**Opções disponíveis:**
-
-**Opção A — Gitignore (recomendada para reposde < 5.000 arquivos):**
-- Adicionar `.agent/skills/` e `.agents/skills/` ao `.gitignore`
-- `git rm -r --cached .agent/skills/ .agents/skills/`
-- Criar um `skills-lock.json` com hashes para reprodutibilidade
-- Risco: a biblioteca não fica versionada junto ao código
-
-**Opção B — Git Submodule:**
-- Mover `.agent/skills/` para repositório separado `ghost-skills-library`
-- Referenciar como submodule
-- Mantém versionamento, isola o peso do repo principal
-
-**Opção C — Manter como está:**
-- Nenhuma alteração
-- Aceitar truncamento do GitHub (apenas cosmético, não funcional)
-
-**Validação após execução (qualquer opção):**
-- [ ] `git ls-files | wc -l` deve estar abaixo de 2.000 após R1-R4
-- [ ] GitHub não deve mais mostrar aviso de truncamento
-- [ ] Build do Next.js deve continuar funcional: `pnpm run build`
-
----
-
-## FASE P0 — Ghost Design System
-
-### G1 — Corrigir violação de `rotate` em `CategoryStripe.tsx`
-**Responsável:** Motion Governance Specialist
-**Prioridade:** BLOQUEANTE
-**Arquivo:** `src/components/home/portfolio-showcase/CategoryStripe.tsx:163`
-
-**Diagnóstico:**
-```tsx
-// LINHA 163 - VIOLAÇÃO: rotate é proibido pelo Ghost System
-animate={{
-  y: isHovered ? -1 : 0,
-  rotate: isHovered ? 0 : -45,  // ❌ PROIBIDO
-  backgroundColor: isHovered ? COLORS.purpleDetails : COLORS.bluePrimary,
-}}
-```
-
-**Solução aprovada:**
-- Remover `rotate` do `animate`
-- Substituir pela exibição condicional de dois ícones com `opacity`:
-  - Ícone 1: `ArrowUpRight` (diagonal) com `opacity: isHovered ? 0 : 1`
-  - Ícone 2: `ArrowUp` (vertical) com `opacity: isHovered ? 1 : 0`
-- Ambos com `transition: { duration: MOTION_TOKENS.duration.modal, ease: GHOST_EASE }`
-- Posicionar com `absolute` + `inset-0` para sobreposição sem layout shift
-
-**Passos:**
-- [ ] Ler o arquivo completo: `src/components/home/portfolio-showcase/CategoryStripe.tsx`
-- [ ] Remover a prop `rotate` do `animate` object na linha 163
-- [ ] Implementar dois ícones sobrepostos com transição por `opacity`
-- [ ] Verificar: `grep -n "rotate" src/components/home/portfolio-showcase/CategoryStripe.tsx` deve retornar 0
-- [ ] Executar `pnpm run typecheck` — deve passar sem erros no arquivo
-- [ ] Inspecionar visualmente o componente em dev
-
-**Rollback:** `git restore src/components/home/portfolio-showcase/CategoryStripe.tsx`
-
----
-
-### G2 — Criar `src/lib/supabase/image-loader.ts`
-**Responsável:** Supabase Storage Specialist + Next.js App Router Architect
-**Prioridade:** P0
-**Arquivo a criar:** `src/lib/supabase/image-loader.ts`
-
-**Diagnóstico:**
-O `next.config.mjs` já configura `remotePatterns` para o host Supabase. Falta um `loaderFile` customizado que transforme URLs do Storage para otimização via Supabase Image Transformation.
-
-**Especificação do loader:**
-```typescript
-// src/lib/supabase/image-loader.ts
-import type { ImageLoader } from 'next/image';
-
-const supabaseImageLoader: ImageLoader = ({ src, width, quality }) => {
-  // URLs do Supabase Storage usam parâmetros de transformação nativos
-  if (src.includes('/storage/v1/object/public/')) {
-    const url = new URL(src);
-    url.searchParams.set('width', String(width));
-    url.searchParams.set('quality', String(quality ?? 80));
-    url.searchParams.set('format', 'webp');
-    return url.toString();
-  }
-  return src;
-};
-
-export default supabaseImageLoader;
-```
-
-**Passos:**
-- [ ] Criar o arquivo `src/lib/supabase/image-loader.ts` com a implementação acima
-- [ ] Verificar se Supabase do projeto suporta Image Transformation (requer plano Pro ou superior)
-- [ ] Se Image Transformation não disponível: implementar loader sem parâmetros de transform (retorna src original — pelo menos o loader estará disponível para upgrade futuro)
-- [ ] Atualizar `next.config.mjs`: adicionar `images.loaderFile: './src/lib/supabase/image-loader.ts'` na config de images
-- [ ] Executar `pnpm run typecheck` — deve passar
-- [ ] Executar `pnpm run build` — deve compilar sem erro
-- [ ] Verificar que imagens do Supabase continuam carregando corretamente
-
-**Trade-off:** O `loaderFile` customizado substitui o loader padrão do Next.js para TODAS as imagens. URLs que não são do Supabase devem fazer fallback gracioso (linha `return src` no else).
-
-**Rollback:** Remover o arquivo + reverter `next.config.mjs`
-
----
-
-## FASE P1 — Ghost Design System
-
-### G3 — Criar `src/components/motion/MotionLink.tsx`
-**Responsável:** Motion Governance Specialist
-**Prioridade:** P1
-**Arquivo a criar:** `src/components/motion/MotionLink.tsx`
-
-**Especificação:**
-```tsx
-// Wrapper de Link para transições de saída ghost
-// Usa opacity fadeout + translateY sutil ao navegar
-```
-
-**Passos:**
-- [ ] Verificar se `src/components/motion/` existe; criar se necessário
-- [ ] Criar `MotionLink.tsx` wrapping `next/link` com `m.span` e exit animation
-- [ ] Garantir que não quebra navegação via `<a>` direto (accessibility)
-- [ ] Substituir Links críticos: Header nav items, FeaturedProjectCard
-- [ ] Executar `pnpm run typecheck && pnpm run lint`
-- [ ] Testar navegação client-side manualmente
-
-**Rollback:** Remover arquivo + reverter substituições de Link
-
----
-
-### G4 — Documentar uso de `purpleDetails` como exceção intencional
-**Responsável:** Ghost Design System Guardian
-**Prioridade:** P1 (baixo esforço)
-**Arquivo:** `src/components/home/portfolio-showcase/CategoryStripe.tsx:165`
-
-**Passos:**
-- [ ] Adicionar comentário inline na linha 165 documentando a exceção:
-  ```tsx
-  // Ghost Exception: purpleDetails em hover state — permitido por regra 23-design-system §Forbidden
-  backgroundColor: isHovered ? COLORS.purpleDetails : COLORS.bluePrimary,
-  ```
-- [ ] Executar `pnpm run lint` — deve passar
-
----
-
-## Validação Final (após todas as fases)
-
-- [ ] `git ls-files | wc -l` abaixo de 2.000 (ou conforme decisão sobre skills)
-- [ ] `pnpm run typecheck` — zero erros
-- [ ] `pnpm run lint` — zero erros
-- [ ] `pnpm run build` — build completo sem erro
-- [ ] `grep -n "rotate" src/components/home/portfolio-showcase/CategoryStripe.tsx` retorna 0
-- [ ] `src/lib/supabase/image-loader.ts` existe e exporta função padrão
-- [ ] GitHub não exibe mais aviso de truncamento de diretório
-- [ ] Atualizar `.context/active_state.md` com o novo estado do repositório
-
----
-
-## Plano de Rollback Global
-
-Se qualquer etapa de git rm causar regressão inesperada:
-```bash
-git stash          # salva estado atual
-git restore --staged .   # remove staging
-git stash pop      # restaura arquivos
-```
-
-Para rollback de código (G1, G2, G3):
-```bash
-git restore src/components/home/portfolio-showcase/CategoryStripe.tsx
-git restore src/lib/supabase/image-loader.ts
-git restore next.config.mjs
-```
-
----
-
-*Ghost Audit Pipeline | Task Manifest | 2026-05-17 | Aguardando: APROVAÇÃO HUMANA*

--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-05-18T09:02:10.620Z",
+  "buildTimeISO": "2026-05-18T22:30:57.722Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/components/ui/shared/DynamicAssetImage.tsx
+++ b/src/components/ui/shared/DynamicAssetImage.tsx
@@ -52,6 +52,12 @@ export function DynamicAssetImage({
   }, [asset?.publicUrl, displayUrl]);
 
   const finalUrl = displayUrl || normalizedFallback;
+  const shouldUseSupabaseLoader = Boolean(
+    finalUrl &&
+      !finalUrl.startsWith('/') &&
+      !finalUrl.startsWith('data:') &&
+      !finalUrl.startsWith('blob:')
+  );
 
   if (loading && !fallbackUrl) {
     return (
@@ -105,7 +111,7 @@ export function DynamicAssetImage({
       }
     >
       <Image
-        loader={supabaseLoader}
+        loader={shouldUseSupabaseLoader ? supabaseLoader : undefined}
         src={finalUrl!}
         alt={alt}
         fill={!width && !height}

--- a/src/config/site-assets.ts
+++ b/src/config/site-assets.ts
@@ -29,10 +29,10 @@ export const SITE_ASSET_KEYS = {
   },
   about: {
     originImages: [
-      'about.origin.about.origin_image.1',
-      'about.origin.about.origin_image.2',
-      'about.origin.about.origin_image.3',
-      'about.origin.about.origin_image.4',
+      'about.origin_image.1',
+      'about.origin_image.2',
+      'about.origin_image.3',
+      'about.origin_image.4',
     ],
     methodDesktop: 'about.method.about.method.desktop_video',
     methodMobile: 'about.method.about.method.mobile_video',


### PR DESCRIPTION
### Motivation
- Corrigir a regressão que gerava o warning `next-image-missing-loader-width` ao usar um `loader` custom em imagens locais e reconciliar a divergência de keys entre `site-assets` e o fallback local `/site.assets`.
- Alinhar a implementação à aprovação humana: a seção `06-O-QUE-ME-MOVE` deve permanecer sem animação 3D/Canvas/GSAP conforme a documentação final.
- Reduzir risco de imagem quebrada no build ao garantir que `next/image` trate assets locais nativamente e que o loader Supabase seja usado somente para URLs remotas.

### Description
- Corrigi as chaves de origem em `src/config/site-assets.ts` para `about.origin_image.1`…`about.origin_image.4` de modo a corresponder ao export de assets real usado no projeto.
- Atualizei `src/components/ui/shared/DynamicAssetImage.tsx` para aplicar `supabaseLoader` apenas quando `finalUrl` for remota (não começa com `/`, `data:` ou `blob:`), deixando caminhos locais (`/site.assets/...`) no fluxo nativo do `next/image` (`loader={shouldUseSupabaseLoader ? supabaseLoader : undefined}`).
- Atualizei artefatos e documentação: `docs/implementation_plan.md`, `docs/task.md` e `.context/DOCS-PORTFOLIO-PAGES/02-SOBRE/06-O-QUE-ME-MOVE/walkthrough.md` para registrar a ressalva humana (sem 3D Ghost) e a auditoria de paths; `public/build-info.json` foi atualizado pelo processo de build.

### Testing
- Executados `pnpm run lint` e `pnpm run typecheck` e ambos passaram (ambiente emitiu apenas aviso de engine por Node 20 vs Node 22 esperado).
- Executado `pnpm run build` com sucesso; o build usou fallbacks quando o Supabase remoto ficou inacessível pela rede, sem falhar o processo de compilação.
- Executado `pnpm test` com sucesso: 37 suites / 250 testes passaram.
- Validação prática: `pnpm run dev` + `curl http://127.0.0.1:3000/sobre` retornou HTTP `200` e os logs não apresentaram o warning `next-image-missing-loader-width`.
- Tentativa de captura automatizada via Playwright/Chromium foi executada, mas falhou no ambiente por dependência nativa ausente (`libatk-1.0.so.0`); isso não bloqueia as validações manuais listadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b575e90888330874296b8137d8569)