### PR TITLE
fix(beliefs): shader-lines regression — position fixed → absolute + npm Three.js

### DIFF
--- a/e2e/about-beliefs.spec.ts
+++ b/e2e/about-beliefs.spec.ts
@@ -196,5 +196,38 @@ for (const route of ROUTES) {
 
       expect(hydrationErrors).toHaveLength(0);
     });
+
+    test('shader canvas existe dentro da seção e não vaza para o documento', async ({
+      page,
+    }) => {
+      await expect(
+        page.locator(
+          '[data-testid="beliefs-section"] [data-testid="shader-lines-canvas"] canvas'
+        )
+      ).toBeAttached({ timeout: 10000 });
+
+      // Canvas must be a descendant of the section, not a sibling of body
+      const isInsideSection = await page.evaluate(() => {
+        const section = document.querySelector(
+          '[data-testid="beliefs-section"]'
+        );
+        const canvas = document.querySelector(
+          '[data-testid="shader-lines-canvas"] canvas'
+        );
+        return section !== null && canvas !== null && section.contains(canvas);
+      });
+
+      expect(isInsideSection).toBe(true);
+    });
+
+    test('background usa position:absolute (não fixed) — guard de regressão', async ({
+      page,
+    }) => {
+      const position = await page
+        .locator('[data-testid="what-moves-me-background"]')
+        .evaluate((el) => window.getComputedStyle(el).position);
+
+      expect(position).toBe('absolute');
+    });
   });
 }

--- a/src/components/sobre/beliefs/WhatMovesMeBackground.tsx
+++ b/src/components/sobre/beliefs/WhatMovesMeBackground.tsx
@@ -1,22 +1,38 @@
+'use client';
+
+import { ShaderAnimation } from '@/components/ui/shader-lines';
+
 export function WhatMovesMeBackground() {
   return (
     <div
       aria-hidden="true"
       data-testid="what-moves-me-background"
       style={{
-        position: 'fixed',
+        position: 'absolute',
         inset: 0,
         zIndex: 0,
-        background: [
-          'radial-gradient(ellipse 80% 60% at 50% 50%, #0048ff22 0%, transparent 70%)',
-          'radial-gradient(ellipse 50% 40% at 20% 80%, #8705f218 0%, transparent 60%)',
-          'radial-gradient(ellipse 40% 30% at 80% 20%, #4fe6ff10 0%, transparent 50%)',
-          '#040013',
-        ].join(', '),
         pointerEvents: 'none',
+        overflow: 'hidden',
       }}
     >
-      {/* grid lines */}
+      {/* Layer 0: WebGL shader lines — contained to this section */}
+      <ShaderAnimation />
+
+      {/* Layer 1: Ghost Blue radial glow */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: [
+            'radial-gradient(ellipse 80% 60% at 50% 50%, #0048ff22 0%, transparent 70%)',
+            'radial-gradient(ellipse 50% 40% at 20% 80%, #8705f218 0%, transparent 60%)',
+            'radial-gradient(ellipse 40% 30% at 80% 20%, #4fe6ff10 0%, transparent 50%)',
+          ].join(', '),
+        }}
+      />
+
+      {/* Layer 2: grid lines */}
       <div
         style={{
           position: 'absolute',
@@ -26,7 +42,8 @@ export function WhatMovesMeBackground() {
             'repeating-linear-gradient(90deg, transparent 79px, #0048ff0a 80px), repeating-linear-gradient(0deg, transparent 79px, #0048ff06 80px)',
         }}
       />
-      {/* vignette */}
+
+      {/* Layer 3: edge vignette */}
       <div
         style={{
           position: 'absolute',

--- a/src/components/ui/shader-lines.tsx
+++ b/src/components/ui/shader-lines.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import * as THREE from "three"
+
+export function ShaderAnimation() {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const container = containerRef.current
+
+    const vertexShader = `
+      void main() {
+        gl_Position = vec4(position, 1.0);
+      }
+    `
+
+    const fragmentShader = `
+      #define TWO_PI 6.2831853072
+
+      precision highp float;
+      uniform vec2 resolution;
+      uniform float time;
+
+      float random(in float x) {
+        return fract(sin(x) * 1e4);
+      }
+
+      float random(vec2 st) {
+        return fract(sin(dot(st.xy, vec2(12.9898, 78.233))) * 43758.5453123);
+      }
+
+      void main(void) {
+        vec2 uv = (gl_FragCoord.xy * 2.0 - resolution.xy) / min(resolution.x, resolution.y);
+
+        vec2 fMosaicScal = vec2(4.0, 2.0);
+        vec2 vScreenSize = vec2(256.0, 256.0);
+        uv.x = floor(uv.x * vScreenSize.x / fMosaicScal.x) / (vScreenSize.x / fMosaicScal.x);
+        uv.y = floor(uv.y * vScreenSize.y / fMosaicScal.y) / (vScreenSize.y / fMosaicScal.y);
+
+        float t = time * 0.06 + random(uv.x) * 0.4;
+        float lineWidth = 0.0008;
+
+        vec3 color = vec3(0.0);
+        for(int j = 0; j < 3; j++){
+          for(int i = 0; i < 5; i++){
+            color[j] += lineWidth * float(i * i) / abs(
+              fract(t - 0.01 * float(j) + float(i) * 0.01) * 1.0 - length(uv)
+            );
+          }
+        }
+
+        gl_FragColor = vec4(color[2], color[1], color[0], 1.0);
+      }
+    `
+
+    const camera = new THREE.Camera()
+    camera.position.z = 1
+
+    const scene = new THREE.Scene()
+    const geometry = new THREE.PlaneGeometry(2, 2)
+
+    const uniforms = {
+      time: { value: 1.0 },
+      resolution: { value: new THREE.Vector2() },
+    }
+
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader,
+      fragmentShader,
+    })
+
+    scene.add(new THREE.Mesh(geometry, material))
+
+    const renderer = new THREE.WebGLRenderer({ antialias: false, alpha: false })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+
+    const canvas = renderer.domElement
+    canvas.style.position = "absolute"
+    canvas.style.inset = "0"
+    canvas.style.width = "100%"
+    canvas.style.height = "100%"
+    canvas.setAttribute("aria-hidden", "true")
+    container.appendChild(canvas)
+
+    const onResize = () => {
+      const w = container.clientWidth
+      const h = container.clientHeight
+      renderer.setSize(w, h, false)
+      uniforms.resolution.value.set(canvas.width, canvas.height)
+    }
+
+    onResize()
+    window.addEventListener("resize", onResize, { passive: true })
+
+    let animationId = 0
+    const animate = () => {
+      animationId = requestAnimationFrame(animate)
+      uniforms.time.value += 0.05
+      renderer.render(scene, camera)
+    }
+    animate()
+
+    return () => {
+      cancelAnimationFrame(animationId)
+      window.removeEventListener("resize", onResize)
+      if (container.contains(canvas)) container.removeChild(canvas)
+      renderer.dispose()
+      geometry.dispose()
+      material.dispose()
+    }
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="shader-lines-canvas"
+      style={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+        background: "#040013",
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `WhatMovesMeBackground` used `position: 'fixed'` which positioned the background relative to the viewport (not its parent section), hiding images and videos in all other sections (`AboutOrigin`, `AboutHero`, `AboutWhatIDo`, etc.) with `zIndex: 0`
- Fixed to `position: 'absolute'` so the background is contained within `#o-que-me-move`
- Refactored `shader-lines.tsx` to use the project's existing npm Three.js instead of CDN r89 injection — fixes `PlaneBufferGeometry` (removed in Three.js r150), removes undeclared `varying vUv`, adds proper `pointerEvents: none` + `inset-0` container + canvas CSS constraints + correct disposal
- Integrated `ShaderAnimation` into `WhatMovesMeBackground` as layer-0, with gradient overlays (radial glow, grid, vignette) above it

## Files changed

| File | Change |
|---|---|
| `src/components/sobre/beliefs/WhatMovesMeBackground.tsx` | `fixed` → `absolute`, integrate `<ShaderAnimation />` |
| `src/components/ui/shader-lines.tsx` | Replace CDN+window.THREE with npm Three.js, fix geometry API, container/canvas CSS, disposal |
| `e2e/about-beliefs.spec.ts` | +2 regression guards: canvas inside section, background `position === 'absolute'` |

## Test plan

- [ ] Run `pnpm run typecheck` → exit 0
- [ ] Run `pnpm run lint` → exit 0
- [ ] Manually verify `/sobre` — all sections (hero, origin, what-i-do, method, beliefs, closing) render correctly
- [ ] Scroll through `#o-que-me-move` — shader lines visible, phrases animate, manifesto appears at climax
- [ ] Run `pnpm test:e2e -- e2e/about-beliefs.spec.ts` — all tests pass including two new regression guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)