### PR TITLE
fix(ci): remove backslash escapes from GitHub Actions expressions

### DIFF
--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -143,7 +143,7 @@ jobs:
               --body "## Falha Corrigida
 
             **Workflow:** ${{ env.FAILED_WORKFLOW }}
-            **Run ID:** [${{ env.FAILED\_RUN\_ID }}\](https://github.com/${{ github.repository }}/actions/runs/${{ env.FAILED_RUN_ID }})
+            **Run ID:** [${{ env.FAILED_RUN_ID }}](https://github.com/${{ github.repository }}/actions/runs/${{ env.FAILED_RUN_ID }})
 
             ## Diagnóstico
             <causa raiz identificada nos logs>


### PR DESCRIPTION
## Summary

- Fix `Invalid workflow file` error in `claude-autofix.yml`

## Root cause

`${{ env.FAILED\_RUN\_ID }}` — backslash before underscore is invalid in GitHub Actions expression syntax. GitHub parses `${{ }}` expressions **before** Markdown rendering, so `\_` is treated as a literal character making `FAILED\_RUN\_ID` an unknown identifier.

**Error:** `(Line: 72, Col: 19): Unexpected symbol: 'FAILED\_RUN\_ID'. Located at position 5 within expression: env.FAILED\_RUN\_ID`

## Change

```diff
- **Run ID:** [${{ env.FAILED\_RUN\_ID }}\](https://.../${{ env.FAILED_RUN_ID }})
+ **Run ID:** [${{ env.FAILED_RUN_ID }}](https://.../${{ env.FAILED_RUN_ID }})
```

## Test plan
- [ ] Workflow file passes GitHub Actions YAML validation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)