### PR TITLE
Potential fix for code scanning alert no. 37380: DOM text reinterpreted as HTML

### DIFF
--- a/skills/superpower/brainstorming/scripts/helper.js
+++ b/skills/superpower/brainstorming/scripts/helper.js
@@ -58,15 +58,23 @@
           selected[0]
             .querySelector('h3, .content h3, .card-body h3')
             ?.textContent?.trim() || selected[0].dataset.choice;
-        indicator.innerHTML =
-          '<span class="selected-text">' +
-          label +
-          ' selected</span> — return to terminal to continue';
+        indicator.textContent = '';
+        const selectedText = document.createElement('span');
+        selectedText.className = 'selected-text';
+        selectedText.textContent = label + ' selected';
+        indicator.appendChild(selectedText);
+        indicator.appendChild(
+          document.createTextNode(' — return to terminal to continue')
+        );
       } else {
-        indicator.innerHTML =
-          '<span class="selected-text">' +
-          selected.length +
-          ' selected</span> — return to terminal to continue';
+        indicator.textContent = '';
+        const selectedText = document.createElement('span');
+        selectedText.className = 'selected-text';
+        selectedText.textContent = selected.length + ' selected';
+        indicator.appendChild(selectedText);
+        indicator.appendChild(
+          document.createTextNode(' — return to terminal to continue')
+        );
       }
     }, 0);
   });


### PR DESCRIPTION
Potential fix for [https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37380](https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37380)

Use safe DOM APIs so untrusted/dynamic values are assigned as text, not parsed as HTML.

Best fix here: replace both `indicator.innerHTML = ...` branches with creation of a `<span class="selected-text">` element and assign dynamic parts with `textContent`. Then append a plain text suffix (`' — return to terminal to continue'`). This preserves the existing visual structure (`selected-text` span + suffix) without changing behavior.

Edit only `skills/superpower/brainstorming/scripts/helper.js`, specifically inside the `setTimeout` block around lines 61–69.

No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
