### PR TITLE
docs: restore ghost hero PR traceability

### DIFF
--- a/docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md
+++ b/docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md
@@ -88,6 +88,10 @@ Important caveat: Firebase's webframeworks deploy path also updated the SSR Clou
 
 Local production validation was completed with `.next/standalone` after copying `.next/static` and `public` into the standalone folder for accurate asset serving.
 
+## PR Recovery Note
+
+This branch was opened after the local merge to restore Pull Request traceability. The Ghost glow and portfolio hero files were verified on `origin/main` before this PR branch was created.
+
 ## Remaining Risks
 
 - The portfolio hero source video itself contains frames where campaign cards are partially outside the composition. CSS now preserves the video frame with `contain`; changing to `cover` would crop more, not less.


### PR DESCRIPTION
## Summary
- Adds a PR recovery note to the Ghost 3D brightness and portfolio hero walkthrough.
- Confirms the Ghost glow and portfolio hero files were verified on origin/main before opening this traceability branch.

## Verification
- Verified GitHub API can read docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md on main.
- Prior merged validation: targeted Jest, lint, build, and typecheck passed.