### PR TITLE
fix: add final ghost hero files

### DIFF
--- a/.context/DOCS-PORTFOLIO-PAGES/03-PORTFOLIO/02-HERO/02-HERO.md
+++ b/.context/DOCS-PORTFOLIO-PAGES/03-PORTFOLIO/02-HERO/02-HERO.md
@@ -3,7 +3,7 @@
 ## 0. Estrutura de arquivos da sessão
 
 - `src/components/portfolio/PortfolioHeroNew.tsx`
-- `src/components/ui/shared/DynamicAssetVideo.tsx`
+- `src/components/ui/shared/ResponsiveVideo.tsx`
 - `src/config/content.ts`
 - `src/config/site-assets.ts`
 - `src/hooks/useMotionGate.ts`
@@ -34,9 +34,10 @@ Abrir a página com presença visual forte (vídeo desktop/mobile), título edit
 ## 5. Responsividade
 
 - Troca de asset por breakpoint (`heroDesktop`/`heroMobile`).
-- Tipografia escala de `text-4xl` até `text-8xl`.
-- Vídeo hero é full-bleed em desktop e mobile: `section#portfolio-hero` rompe o wrapper `.std-grid` com `w-screen` e `left-1/2 -translate-x-1/2`.
-- O vídeo usa `object-cover` e ocupa toda a largura do viewport até as bordas da página.
+- Tipografia escala com `clamp()` no mobile e `md:text-8xl` no desktop.
+- Vídeo hero é full-bleed em desktop e mobile: `section#portfolio-hero` rompe o wrapper `.std-grid` com `w-screen`, `max-w-none`, `min-h-[100svh]` e `left-1/2 -translate-x-1/2`.
+- O vídeo ocupa toda a largura/altura do viewport (`w-full h-full min-w-full max-w-none`) e mantém `object-contain` para preservar as laterais do asset.
+- No mobile, "portfólio" e "showcase" empilham para evitar corte lateral do título.
 
 ## 6. Acessibilidade e SEO
 
@@ -49,8 +50,10 @@ Abrir a página com presença visual forte (vídeo desktop/mobile), título edit
   - bom fallback para ausência de motion.
   - centralização de source via `SITE_ASSET_KEYS`.
   - validação local em `2026-05-02`: `fullBleedX: true` para desktop `1440px` e mobile `390px`, sem erro de mídia.
+  - validação local em `2026-05-22`: dev e standalone production com `heroRect.left=0`, `heroRect.right=viewport`, `videoCount=1`, source desktop/mobile correto e `object-fit: contain`.
 - Riscos:
   - custo de LCP se asset hero não estiver otimizado no storage.
+  - alguns frames do próprio vídeo podem conter cards parcialmente fora da composição; isso é conteúdo do asset, não crop CSS.
 
 ## 8. Inconformidades observadas
 

--- a/.context/active_state.md
+++ b/.context/active_state.md
@@ -1,20 +1,44 @@
-# Active State: MANIFESTO CAROUSEL & WEBGL SHADER REALIGNMENT ✅
+# Active State: GHOST 3D BRIGHTNESS & PORTFOLIO HERO FULL BLEED ✅
 
-**Phase**: MANIFESTO CAROUSEL & WEBGL SHADER REALIGNMENT
-**Current Focus**: Alinhamento do Manifesto "O que me move" na página `/sobre` (e rota `/o-que-me-move`) com a referência HTML: pulsing gradient Three.js fragment shader pixelado + transições CSS scoped stagger por caractere + dots tácteis + autoplay robusto + acessibilidade WCAG.
-**Last Update**: 2026-05-21 16:25
+**Phase**: GHOST 3D BRIGHTNESS & PORTFOLIO HERO FULL BLEED
+**Current Focus**: Consistência do brilho/Bloom do Ghost 3D entre dev/build e hero `/portfolio` em full bleed real com vídeo responsivo sem corte CSS lateral.
+**Last Update**: 2026-05-22 12:08
 **Production URL**: https://portfolio-danilo-novais.web.app
 **Cloud Function**: https://ssrportfoliodanilo-qc26fkohcq-uc.a.run.app
 
 ## Deploy Summary
 
 - **Build**: ✅ Next.js 16.2.6 (Webpack) — Stable production build completed
+- **Ghost 3D**: ✅ Renderer explicitado com `SRGBColorSpace`, ACES Filmic e Bloom preservado em desktop `medium`.
+- **Portfolio Hero**: ✅ `section#portfolio-hero` validada em full bleed 0→viewport desktop/mobile, vídeo único e source desktop/mobile correto.
 - **ResponsiveVideo**: ✅ Silenced DOM AbortError warnings during rapid mounts or component unmounting
 - **Manifesto**: ✅ Integrated `ManifestoScrollSection` on `/sobre` and `/o-que-me-move` routes
 - **WebGL**: ✅ Realigned procedural gradient fragment shader (Blue/Purple/Blue) in `shader-lines.tsx`
 - **Validation**: ✅ 100% stable `build-check` and `build` under absolute Node v26 and pnpm resolution path
 - **Visual Regressions**: ✅ Resolved background shader invisible stacking context and closing video unmounting buffering failures
 - **Email Integration**: ✅ Integrated Resend API for contact form submissions dispatching to danilo@portfoliodanilo.com
+
+## Ghost 3D Brightness & Portfolio Hero Full Bleed (2026-05-22)
+
+- [x] **Renderer Determinism**: `src/components/canvas/home/hero/hooks/useGhostScene.ts` now sets `renderer.outputColorSpace = THREE.SRGBColorSpace`, keeps ACES Filmic tone mapping, and exposes canvas QA attributes for output color space, tone mapping, quality, and post-processing.
+- [x] **Bloom Consistency**: `src/hooks/usePerformanceAdaptive.ts` keeps post-processing enabled for desktop `medium` quality while lowering DPR to `1.25`; `low` remains without post-processing.
+- [x] **Ghost Glow Tuning**: `src/components/canvas/home/hero/hooks/useGhostParams.ts` raises emissive/Bloom/exposure values within Ghost Blue/Cyan identity to avoid dim deploy renders.
+- [x] **Portfolio Full Bleed**: `src/components/portfolio/PortfolioHeroNew.tsx` uses `min-h-[100svh]`, `max-w-none`, `w-screen`, and a single `ResponsiveVideo` with full viewport dimensions.
+- [x] **No CSS Side Crop**: `portfolioHero.fitPolicy` remains `contain`; video sides are preserved by CSS. Any partial off-screen cards in frames are part of the source asset composition.
+- [x] **Mobile Title Fit**: Mobile heading stacks `portfólio` over `showcase`, preventing the title from being clipped at 390px width.
+- [x] **Validation Evidence**:
+  - `pnpm exec jest test/unit/hooks/usePerformanceAdaptive.test.ts test/components/portfolio/PortfolioHeroNew.test.tsx --runInBand` ✅ `9 passed`
+  - `pnpm run lint` ✅ exit code 0
+  - `pnpm run build` ✅ exit code 0
+  - `pnpm run typecheck` ✅ exit code 0
+  - Dev and standalone production screenshots saved in `docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/evidence/`
+  - Standalone local validation required copying `.next/static` and `public` into `.next/standalone` before screenshot capture; first run without that copy produced expected static 404s and invalid CSS layout.
+- [x] **Firebase Preview Evidence**:
+  - Preview URL: `https://portfolio-danilo-novais--codex-ghost-portfolio-hero-08f82fzk.web.app` (expires `2026-05-29`)
+  - `/` preview: Ghost canvas visible with `data-post-processing="true"`, `data-output-color-space="srgb"` and `data-tone-mapping="aces-filmic"`.
+  - `/portfolio` preview desktop/mobile: hero and video rects start at `left=0` and end at viewport width; single responsive video selected; `object-fit: contain`.
+  - Firebase framework preview also updated SSR Cloud Function `ssrportfoliodanilonovai`; no explicit production Hosting release was requested.
+  - Predeploy audit still reports 42 pre-existing broken legacy asset links in `src/config/site-assets.json`; current critical portfolio hero video URLs returned HTTP 200.
 
 ## ResponsiveVideo Interruption Safeguard & Autoplay Hardening (2026-05-21)
 

--- a/docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md
+++ b/docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md
@@ -1,0 +1,96 @@
+# Ghost 3D Brightness and Portfolio Hero Full Bleed Walkthrough
+
+## Root Cause
+
+Ghost 3D brightness drift was caused by production/runtime quality paths being able to bypass post-processing. `usePerformanceAdaptive()` disabled post-processing for `medium` quality, and `medium` is reachable on high-DPR desktop screens. Because Bloom only renders through the composer path, Ghost could appear flatter after deploy even when the scene itself loaded.
+
+The portfolio hero was already full bleed at the section level, but the implementation had two mismatches:
+
+- docs said `object-cover`, while code used `object-contain`;
+- the mobile title could exceed the viewport because the words stayed in one row inside the heading.
+
+The video side preservation issue is not solved by forcing `cover`; `cover` would crop by design. The fix keeps `contain` so CSS does not cut the video laterals.
+
+## Decisions
+
+- Keep `GhostSceneWrapper` as `dynamic(..., { ssr: false })`.
+- Set `renderer.outputColorSpace = THREE.SRGBColorSpace`.
+- Keep `THREE.ACESFilmicToneMapping`.
+- Keep post-processing enabled on desktop `medium` quality, but reduce DPR to `1.25`.
+- Keep `low` quality without post-processing for low-end/mobile protection.
+- Raise Ghost emissive/Bloom/exposure values conservatively inside Ghost Blue/Cyan identity.
+- Keep portfolio hero `fitPolicy: 'contain'` to avoid CSS side crop.
+- Add `objectPosition="center center"` support to `ResponsiveVideo`.
+- Stack `/portfolio` hero title on mobile so text no longer clips at 390px.
+
+## Files Changed
+
+- `src/hooks/usePerformanceAdaptive.ts`
+- `src/components/canvas/home/hero/hooks/useGhostScene.ts`
+- `src/components/canvas/home/hero/hooks/useGhostParams.ts`
+- `src/components/portfolio/PortfolioHeroNew.tsx`
+- `src/components/ui/shared/ResponsiveVideo.tsx`
+- `test/unit/hooks/usePerformanceAdaptive.test.ts`
+- `test/components/portfolio/PortfolioHeroNew.test.tsx`
+- `.context/DOCS-PORTFOLIO-PAGES/03-PORTFOLIO/02-HERO/02-HERO.md`
+- `.context/active_state.md`
+
+## Evidence
+
+Baseline:
+
+- `evidence/baseline-home-desktop.png`
+- `evidence/baseline-metrics.json`
+
+Production local after build:
+
+- `evidence/prod-fixed-home-desktop.png`
+- `evidence/prod-fixed-portfolio-desktop.png`
+- `evidence/prod-fixed-portfolio-mobile.png`
+- `evidence/prod-fixed-metrics.json`
+
+Firebase preview:
+
+- URL: `https://portfolio-danilo-novais--codex-ghost-portfolio-hero-08f82fzk.web.app`
+- `evidence/preview-home-desktop.png`
+- `evidence/preview-portfolio-desktop.png`
+- `evidence/preview-portfolio-mobile.png`
+- `evidence/preview-metrics.json`
+
+Key metrics:
+
+- `/portfolio` desktop: `heroRect.left=0`, `heroRect.right=1440`, `videoCount=1`, desktop MP4 selected, `objectFit=contain`.
+- `/portfolio` mobile: `heroRect.left=0`, `heroRect.right=390`, `videoCount=1`, mobile MP4 selected, `objectFit=contain`.
+- `/` production local: Ghost canvas exists, `canvasPostProcessing=true`, `canvasOutputColorSpace=srgb`, `canvasToneMapping=aces-filmic`.
+- `/` Firebase preview: Ghost canvas exists, `canvasPostProcessing=true`, `canvasOutputColorSpace=srgb`, `canvasToneMapping=aces-filmic`.
+
+Validation commands:
+
+```bash
+pnpm exec jest test/unit/hooks/usePerformanceAdaptive.test.ts test/components/portfolio/PortfolioHeroNew.test.tsx --runInBand
+pnpm run lint
+pnpm run build
+pnpm run typecheck
+```
+
+Results:
+
+- Jest: `2 passed`, `9 tests passed`
+- Lint: exit code 0
+- Build: exit code 0
+- Typecheck: exit code 0
+
+## Preview Status
+
+Firebase Hosting preview was deployed to `codex-ghost-portfolio-hero`, expiring on `2026-05-29`.
+
+Important caveat: Firebase's webframeworks deploy path also updated the SSR Cloud Function `ssrportfoliodanilonovai` while creating the preview channel. No explicit production Hosting release was requested, but the framework function update is a shared remote side effect of this Firebase preview flow.
+
+Local production validation was completed with `.next/standalone` after copying `.next/static` and `public` into the standalone folder for accurate asset serving.
+
+## Remaining Risks
+
+- The portfolio hero source video itself contains frames where campaign cards are partially outside the composition. CSS now preserves the video frame with `contain`; changing to `cover` would crop more, not less.
+- Bloom tuning increases visual intensity and GPU cost. Desktop `medium` lowers DPR to offset that cost; mobile/low-end still avoids post-processing.
+- Local validation ran under Node `v26.0.0` with engine warnings because `package.json` wants Node `22`. Commands passed despite warnings.
+- Firebase predeploy still reports 42 pre-existing broken asset links in `src/config/site-assets.json`, including legacy Ghost/3D and older portfolio media paths. The current critical portfolio hero videos returned HTTP 200.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-05-22T06:39:19.302Z",
+  "buildTimeISO": "2026-05-22T18:54:01.242Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/components/canvas/home/hero/hooks/useGhostParams.ts
+++ b/src/components/canvas/home/hero/hooks/useGhostParams.ts
@@ -11,9 +11,9 @@ export function useGhostParams(performanceConfig: any): GhostSceneParams {
       eyeGlowColor: 'violet',
       ghostOpacity: 0.92,
       ghostScale: 2.4,
-      emissiveIntensity: 1.8, // Reduced further from 2.8 to 1.8 for an ultra-subtle elegant glow
+      emissiveIntensity: 2.4,
       pulseSpeed: 1.4,
-      pulseIntensity: 0.12, // Clamp to remove flicker on emissive modulation
+      pulseIntensity: 0.16,
       eyeGlowIntensity: 2.4, // Reduced from 3.8 to 2.4 to stay soft and balanced
       eyeGlowDecay: 0.96,
       eyeGlowResponse: 0.35,
@@ -45,15 +45,15 @@ export function useGhostParams(performanceConfig: any): GhostSceneParams {
       analogJitter: 0.15,
       limboMode: false,
       // Environment & Post-Processing
-      bloomStrength: performanceConfig.quality === 'low' ? 0.18 : 0.35,
-      bloomRadius: 1.1,
+      bloomStrength: performanceConfig.quality === 'low' ? 0.18 : 0.55,
+      bloomRadius: 1.05,
       // Threshold > 0 so only highly emissive pixels bloom — eliminates frame-wide bloom instability
-      bloomThreshold: 0.85,
+      bloomThreshold: 0.65,
       ambientLightColor: 0x040013,
       ambientLightIntensity: 0.05,
       rimLightColor1: 0x0048ff, // Ghost System Primary Blue
       rimLightColor2: 0x4fe6ff, // Ghost System Accent Blue
-      exposure: 0.95,
+      exposure: 1.05,
     };
   }, [performanceConfig]);
 }

--- a/src/components/canvas/home/hero/hooks/useGhostScene.ts
+++ b/src/components/canvas/home/hero/hooks/useGhostScene.ts
@@ -66,6 +66,7 @@ export function useGhostScene(
     // Cap DPR at 1.5 — bloom cost scales quadratically with pixel ratio on retina
     renderer.setPixelRatio(Math.min(performanceConfig.pixelRatio, 1.5));
     renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = params.exposure;
     renderer.setClearColor(0x000000, 0);
@@ -88,6 +89,12 @@ export function useGhostScene(
       'Interactive 3D Ghost Portfolio Experience'
     );
     renderer.domElement.setAttribute('role', 'img');
+    renderer.domElement.dataset.ghostQuality = performanceConfig.quality;
+    renderer.domElement.dataset.postProcessing = String(
+      performanceConfig.enablePostProcessing
+    );
+    renderer.domElement.dataset.outputColorSpace = 'srgb';
+    renderer.domElement.dataset.toneMapping = 'aces-filmic';
 
     mountElement.appendChild(renderer.domElement);
     rendererRef.current = renderer;

--- a/src/components/portfolio/PortfolioHeroNew.tsx
+++ b/src/components/portfolio/PortfolioHeroNew.tsx
@@ -33,7 +33,7 @@ export default function PortfolioHeroNew() {
     <section
       id="portfolio-hero"
       aria-labelledby="portfolio-hero-heading"
-      className="relative left-1/2 z-10 h-screen w-screen -translate-x-1/2 overflow-hidden bg-background"
+      className="relative left-1/2 z-10 h-screen min-h-[100svh] w-screen max-w-none -translate-x-1/2 overflow-hidden bg-background"
     >
       {/* Video Background - Responsivo Desktop/Mobile com Sincronização Realtime */}
       <div className="absolute inset-0 z-0">
@@ -44,7 +44,8 @@ export default function PortfolioHeroNew() {
             desktopPoster={HERO_POSTER}
             mobilePoster={HERO_POSTER}
             fitPolicy={RESPONSIVE_VIDEOS.portfolioHero.fitPolicy}
-            className="h-full w-screen object-contain"
+            objectPosition="center center"
+            className="h-full w-full min-w-full max-w-none"
             preload="auto"
             autoPlay
             loop
@@ -81,10 +82,10 @@ export default function PortfolioHeroNew() {
           {/* Title - "portfólio showcase" - Centered */}
           <h1
             id="portfolio-hero-heading"
-            className="text-4xl sm:text-6xl md:text-8xl tracking-tighter leading-none font-bold text-center flex flex-col md:flex-row items-center justify-center gap-4 md:gap-8 [text-shadow:0_12px_34px_rgba(0,0,0,0.55)]"
+            className="flex max-w-full flex-col items-center justify-center gap-2 text-center text-[clamp(2.5rem,12vw,4rem)] font-bold leading-none tracking-tighter sm:text-6xl md:flex-row md:gap-8 md:text-8xl [text-shadow:0_12px_34px_rgba(0,0,0,0.55)]"
           >
-            <div className="flex items-center">
-              <span className="text-bluePrimary italic font-light mr-3 md:mr-6">
+            <div className="flex max-w-full flex-col items-center md:flex-row">
+              <span className="text-bluePrimary mb-1 italic font-light md:mb-0 md:mr-6">
                 portfólio
               </span>
               <span className="text-white font-bold">showcase</span>

--- a/src/components/ui/shared/ResponsiveVideo.tsx
+++ b/src/components/ui/shared/ResponsiveVideo.tsx
@@ -11,6 +11,7 @@ export type ResponsiveVideoProps =
     mobilePoster?: string;
     breakpoint?: string;
     fitPolicy?: 'contain' | 'cover';
+    objectPosition?: React.CSSProperties['objectPosition'];
   };
 
 /**
@@ -34,6 +35,8 @@ export const ResponsiveVideo = forwardRef<
       loop = true,
       playsInline = true,
       className = '',
+      objectPosition,
+      style,
       children,
       ...rest
     },
@@ -53,6 +56,7 @@ export const ResponsiveVideo = forwardRef<
         loop={loop}
         playsInline={playsInline}
         className={cn(objectFitClass, className)}
+        style={{ objectPosition, ...style }}
         {...rest}
       >
         {hasMobile && (

--- a/src/hooks/usePerformanceAdaptive.ts
+++ b/src/hooks/usePerformanceAdaptive.ts
@@ -88,8 +88,8 @@ export function usePerformanceAdaptive(): PerformanceConfig {
       quality: 'medium',
       fireflyCount: 12,
       particleCount: 25,
-      enablePostProcessing: false,
-      pixelRatio: 1.5,
+      enablePostProcessing: true,
+      pixelRatio: 1.25,
     },
     low: {
       quality: 'low',

--- a/test/components/portfolio/PortfolioHeroNew.test.tsx
+++ b/test/components/portfolio/PortfolioHeroNew.test.tsx
@@ -18,8 +18,15 @@ jest.mock('next/image', () => ({
     },
 }));
 jest.mock('@/components/ui/shared/ResponsiveVideo', () => ({
-    ResponsiveVideo: ({ desktopSrc, mobileSrc }: { desktopSrc: string; mobileSrc: string }) => (
-        <div data-testid="dynamic-video" data-desktop-src={desktopSrc} data-mobile-src={mobileSrc}>
+    ResponsiveVideo: ({ desktopSrc, mobileSrc, fitPolicy, objectPosition, className }: { desktopSrc: string; mobileSrc: string; fitPolicy?: string; objectPosition?: string; className?: string }) => (
+        <div
+            data-testid="dynamic-video"
+            data-desktop-src={desktopSrc}
+            data-mobile-src={mobileSrc}
+            data-fit-policy={fitPolicy}
+            data-object-position={objectPosition}
+            data-class-name={className}
+        >
             Mock Video
         </div>
     ),
@@ -39,6 +46,9 @@ describe('PortfolioHeroNew Component', () => {
         const videoElement = screen.getByTestId('dynamic-video');
         expect(videoElement).toBeInTheDocument();
         expect(videoElement).toHaveAttribute('data-desktop-src', RESPONSIVE_VIDEOS.portfolioHero.desktop);
+        expect(videoElement).toHaveAttribute('data-fit-policy', RESPONSIVE_VIDEOS.portfolioHero.fitPolicy);
+        expect(videoElement).toHaveAttribute('data-object-position', 'center center');
+        expect(videoElement).toHaveAttribute('data-class-name', 'h-full w-full min-w-full max-w-none');
     });
 
     it('renders static image when reduced motion is true', () => {

--- a/test/unit/hooks/usePerformanceAdaptive.test.ts
+++ b/test/unit/hooks/usePerformanceAdaptive.test.ts
@@ -71,6 +71,27 @@ describe('usePerformanceAdaptive', () => {
     expect(result.current.fireflyCount).toBe(20);
   });
 
+  it('keeps post-processing enabled on high-DPR desktop medium quality', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        userAgent: 'Desktop',
+        hardwareConcurrency: 12,
+        deviceMemory: 16,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'devicePixelRatio', {
+      value: 3,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePerformanceAdaptive());
+
+    expect(result.current.quality).toBe('medium');
+    expect(result.current.enablePostProcessing).toBe(true);
+    expect(result.current.pixelRatio).toBe(1.25);
+  });
+
   it('should downgrade quality if FPS is low', async () => {
     // Initial high quality
     Object.defineProperty(global, 'navigator', {


### PR DESCRIPTION
## Summary
- Adds the final Ghost 3D brightness files, portfolio hero full-bleed files, tests, generated runtime metadata, and walkthrough requested for review.
- This PR is intentionally based on codex/base-before-ghost-final so the review shows the full 12-file diff from before the fix.

## Files included
- src/components/canvas/home/hero/hooks/useGhostParams.ts
- src/components/canvas/home/hero/hooks/useGhostScene.ts
- src/components/portfolio/PortfolioHeroNew.tsx
- src/components/ui/shared/ResponsiveVideo.tsx
- src/hooks/usePerformanceAdaptive.ts
- test/components/portfolio/PortfolioHeroNew.test.tsx
- test/unit/hooks/usePerformanceAdaptive.test.ts
- next-env.d.ts
- public/build-info.json
- .context/DOCS-PORTFOLIO-PAGES/03-PORTFOLIO/02-HERO/02-HERO.md
- .context/active_state.md
- docs/superpowers/plans/2026-05-22-ghost-portfolio-hero/walkthrough.md

## Verification
- Earlier validation on the merged work: targeted Jest, lint, build, typecheck.
- Current PR diff checked locally: 12 files, 191 insertions, 25 deletions.