### PR TITLE
fix: restore portfolio card thumbnails (Supabase render 403)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -57,11 +57,16 @@
       "Bash(node *)",
       "Bash(ffprobe -v error -select_streams v:0 -show_entries stream=width,height \"https://umkmwbkwvulxtdodzmzf.supabase.co/storage/v1/object/public/site-assets/home/video.manifesto.desk.mp4\")",
       "Bash(ffprobe -v error -select_streams v:0 -show_entries stream=width,height \"https://umkmwbkwvulxtdodzmzf.supabase.co/storage/v1/object/public/site-assets/home/video.manifesto.mobile.mp4\")",
-      "Skill(superpowers:writing-plans)"
+      "Skill(superpowers:writing-plans)",
+      "mcp__claude_ai_supabase__list_tables",
+      "mcp__claude_ai_supabase__execute_sql",
+      "Bash(pnpm typecheck *)"
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": ["firecrawl-mcp"],
+  "enabledMcpjsonServers": [
+    "firecrawl-mcp"
+  ],
   "enabledPlugins": {
     "Web-Design-plugin@my-plugins": true
   },

--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,5 +1,5 @@
 {
-  "buildTimeISO": "2026-06-03T03:00:55.921Z",
+  "buildTimeISO": "2026-06-03T04:43:00.233Z",
   "gitSha": "",
   "gitShaShort": "",
   "nodeEnv": ""

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -157,15 +157,18 @@ export function supabaseLoader({
       );
 
       if (isObject || isRender) {
-        if (isObject) {
+        // Image Transformations endpoint returns 403 on current Supabase plan.
+        // Serve direct object URL until transforms are re-enabled.
+        if (isRender) {
           url.pathname = url.pathname.replace(
-            '/storage/v1/object/public/',
-            '/storage/v1/render/image/public/'
+            '/storage/v1/render/image/public/',
+            '/storage/v1/object/public/'
           );
         }
-        url.searchParams.set('width', width.toString());
-        url.searchParams.set('quality', (quality || 75).toString());
-        url.searchParams.set('format', 'webp');
+        url.searchParams.delete('width');
+        url.searchParams.delete('quality');
+        url.searchParams.delete('format');
+        url.searchParams.delete('resize');
         return url.toString();
       }
       return src;


### PR DESCRIPTION
## Summary

- Supabase Image Transformations endpoint (`/storage/v1/render/image/public/`) returns **403** on the current plan, breaking webp thumbnails in `ProjectCard`. Video thumbs (mp4) were unaffected because `urls.ts` bypasses transforms for non-transformable formats.
- Patches `supabaseLoader` (`src/lib/utils.ts`) to rewrite render-endpoint URLs back to `/storage/v1/object/public/` and strip `width/quality/format/resize` params, restoring direct delivery.
- Verified via HEAD probes: `/object/public/` → 200, `/render/image/public/?width=...` → 403 on all sampled paths (`civic/key-visual`, `cbre/cbre`, `eudora/eudora`).

## Affected cards now visible

`cbre`, `eudora`, `mapfre`, `tcotton`, `campaign` (Dolce Gusto), `hellmanns-parcerias`, `video-manifesto`, `mercado-livre/ai-video-mp`.

## Trade-off

Full-res webp delivery until Image Transformations is re-enabled on Supabase Pro. LCP heavier on card-dense routes (`/portfolio`). Long-term: either restore Supabase transforms or migrate to a Next.js loader (Vercel image optimization / Cloudinary).

## Test plan

- [ ] `pnpm run dev` → load `/portfolio`, confirm all 15 published projects render thumbs.
- [ ] DevTools Network: confirm card thumb requests hit `/storage/v1/object/public/portfolio-media/...` with no `?width=` params and return 200.
- [ ] Confirm video-card hover preview still plays (no regression on mp4 path).
- [ ] `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading by correcting URL rewriting for hosted media, ensuring served images use the direct object endpoint without unintended transformation parameters.
* **Chores**
  * Updated local configuration to expand allowed runtime actions.
  * Updated build metadata timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->