### PR TITLE
Potential fix for code scanning alert no. 37383: Incomplete URL substring sanitization

### DIFF
--- a/test/e2e/mobile-menu.spec.ts
+++ b/test/e2e/mobile-menu.spec.ts
@@ -112,7 +112,22 @@ async function stubSyntheticSupabase(page: Page) {
 
   await page.route('**/_next/image**', async (route) => {
     const source = new URL(route.request().url()).searchParams.get('url');
-    if (!source?.startsWith(SYNTHETIC_SUPABASE_ORIGIN)) {
+    const allowedOrigin = new URL(SYNTHETIC_SUPABASE_ORIGIN);
+
+    let isAllowedSource = false;
+    if (source) {
+      try {
+        const sourceUrl = new URL(source);
+        isAllowedSource =
+          sourceUrl.protocol === allowedOrigin.protocol &&
+          sourceUrl.hostname === allowedOrigin.hostname &&
+          sourceUrl.port === allowedOrigin.port;
+      } catch {
+        isAllowedSource = false;
+      }
+    }
+
+    if (!isAllowedSource) {
       await route.continue();
       return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37383](https://github.com/danilonovaisv/PORTFOLIO-DANILO-FINAL/security/code-scanning/37383)

Use URL parsing for `source` and compare structured components (`protocol`, `hostname`, and optionally `port`) against the expected synthetic origin, rather than using `startsWith` on the raw string.

Best fix in this file:
- In `test/e2e/mobile-menu.spec.ts`, within the `page.route('**/_next/image**', ...)` handler, replace the `startsWith` check.
- Parse both `SYNTHETIC_SUPABASE_ORIGIN` and `source` with `new URL(...)`.
- If parsing fails or the parsed `source` does not exactly match allowed origin components, call `route.continue()`.

This preserves functionality (only stub images sourced from the synthetic Supabase origin) while removing substring-bypass behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
